### PR TITLE
fix: harden OpenClaw auth wiring for fresh init

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -599,6 +599,7 @@ async function connectEngine(): Promise<BrainEngine> {
     embedding_dimensions: config.embedding_dimensions,
     expansion_model: config.expansion_model,
     base_urls: config.provider_base_urls,
+    provider_auth: config.provider_auth,
     env: { ...process.env },
   });
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -179,6 +179,7 @@ async function initPGLite(opts: {
       embedding_model: opts.aiOpts.embedding_model,
       embedding_dimensions: opts.aiOpts.embedding_dimensions,
       expansion_model: opts.aiOpts.expansion_model,
+      provider_auth: loadConfig()?.provider_auth,
       env: { ...process.env },
     });
     console.log(`  Embedding: ${opts.aiOpts.embedding_model} (${opts.aiOpts.embedding_dimensions ?? '?'}d)`);
@@ -240,6 +241,7 @@ async function initPostgres(opts: {
       embedding_model: opts.aiOpts.embedding_model,
       embedding_dimensions: opts.aiOpts.embedding_dimensions,
       expansion_model: opts.aiOpts.expansion_model,
+      provider_auth: loadConfig()?.provider_auth,
       env: { ...process.env },
     });
     console.log(`  Embedding: ${opts.aiOpts.embedding_model} (${opts.aiOpts.embedding_dimensions ?? '?'}d)`);

--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -44,6 +44,23 @@ function configureFromEnv(): void {
   configureGateway(gatewayConfig);
 }
 
+function currentGatewayEnv(): Record<string, string | undefined> {
+  return gatewayConfig?.env ?? { ...process.env };
+}
+
+function configureGatewayForTestModel(modelArg: string): void {
+  const [providerId] = modelArg.split(':');
+  const recipe = getRecipe(providerId);
+  const dims = recipe?.touchpoints.embedding?.default_dims ?? gatewayConfig.embedding_dimensions ?? 1536;
+  gatewayConfig = {
+    ...gatewayConfig,
+    embedding_model: modelArg,
+    embedding_dimensions: dims,
+    env: currentGatewayEnv(),
+  };
+  configureGateway(gatewayConfig);
+}
+
 function authResolution(recipe: Recipe) {
   return resolveProviderAuth(recipe, gatewayConfig);
 }
@@ -123,15 +140,7 @@ async function runTest(args: string[]): Promise<void> {
 
   // If --model passed, override gateway for this test
   if (modelArg) {
-    const [providerId, ...modelParts] = modelArg.split(':');
-    const modelId = modelParts.join(':');
-    const recipe = getRecipe(providerId);
-    const dims = recipe?.touchpoints.embedding?.default_dims ?? 1536;
-    configureGateway({
-      embedding_model: modelArg,
-      embedding_dimensions: dims,
-      env: { ...process.env },
-    });
+    configureGatewayForTestModel(modelArg);
   }
 
   if (!gwIsAvailable('embedding')) {
@@ -323,11 +332,13 @@ function consFor(r: Recipe): string[] {
 }
 
 function pickRecommended(options: ProviderOption[], env: Record<string, boolean>, ollamaReady: boolean): { id: string; reason: string } {
-  // Embedding recommendation: prefer env-ready native providers in this order.
   const embOpts = options.filter(o => o.touchpoint === 'embedding');
-  if (env.OPENAI_API_KEY) {
-    const openai = embOpts.find(o => o.id.startsWith('openai:'));
-    if (openai) return { id: openai.id, reason: 'OPENAI_API_KEY set — OpenAI default is high-quality and preserves existing 1536-dim schema.' };
+  const readyOpenAI = embOpts.find(o => o.id.startsWith('openai:') && o.env_ready);
+  if (readyOpenAI) {
+    const reason = readyOpenAI.auth_source === 'env'
+      ? 'OPENAI_API_KEY set — OpenAI default is high-quality and preserves existing 1536-dim schema.'
+      : `OpenAI auth resolved via ${readyOpenAI.auth_source} — default model stays compatible with the existing 1536-dim schema.`;
+    return { id: readyOpenAI.id, reason };
   }
   if (ollamaReady) {
     const ollama = embOpts.find(o => o.id.startsWith('ollama:'));
@@ -341,9 +352,8 @@ function pickRecommended(options: ProviderOption[], env: Record<string, boolean>
     const voyage = embOpts.find(o => o.id.startsWith('voyage:'));
     if (voyage) return { id: voyage.id, reason: 'VOYAGE_API_KEY set — Voyage at 1024 dims.' };
   }
-  // Nothing ready. Recommend OpenAI as the lowest-friction path.
   return {
     id: 'openai:text-embedding-3-large',
-    reason: 'No provider env detected. OpenAI is the fastest setup — get a key at https://platform.openai.com/api-keys.',
+    reason: 'No provider auth detected. OpenAI is the fastest setup — get a key at https://platform.openai.com/api-keys or configure OpenClaw provider_auth.',
   };
 }

--- a/src/core/ai/auth.ts
+++ b/src/core/ai/auth.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { join } from 'path';
+import { isAbsolute, join } from 'path';
 import { homedir } from 'os';
 
 import type { AIGatewayConfig, AuthResolution, ProviderAuthConfig, Recipe } from './types.ts';
@@ -71,7 +71,7 @@ function resolveEnvAuth(recipe: Recipe, env: Record<string, string | undefined>)
 
 function resolveOpenClawProfileAuth(recipe: Recipe, config: AIGatewayConfig, providerConfig: ProviderAuthConfig): AuthResolution {
   const profile = providerConfig.profile ?? defaultProfileForRecipe(recipe);
-  const path = providerConfig.openclawAuthPath ?? defaultOpenClawAuthPath();
+  const path = resolveOpenClawAuthPath(providerConfig.openclawAuthPath);
   const raw = readOpenClawAuthRecord(path, profile);
   if (!raw) {
     return missingResolution(recipe, providerConfig, `OpenClaw profile \"${profile}\" not found at ${path}`);
@@ -129,9 +129,17 @@ function defaultOpenClawAuthPath(): string {
   return join(homedir(), '.openclaw', 'auth.json');
 }
 
+function resolveOpenClawAuthPath(pathOverride?: string): string {
+  const explicit = pathOverride || process.env.GBRAIN_OPENCLAW_AUTH_PATH || process.env.OPENCLAW_AUTH_PATH;
+  if (!explicit) return defaultOpenClawAuthPath();
+  if (isAbsolute(explicit)) return explicit;
+  return join(homedir(), explicit.replace(/^~\//, ''));
+}
+
 function readOpenClawAuthRecord(path: string, profile: string): Record<string, unknown> | null {
   try {
-    const raw = JSON.parse(readFileSync(path, 'utf-8'));
+    const resolvedPath = resolveOpenClawAuthPath(path);
+    const raw = JSON.parse(readFileSync(resolvedPath, 'utf-8'));
     return findProfileRecord(raw, profile);
   } catch {
     return null;

--- a/test/ai/auth.test.ts
+++ b/test/ai/auth.test.ts
@@ -14,15 +14,23 @@ if (!openai) throw new Error('openai recipe missing');
 describe('provider auth resolver', () => {
   let tempDir: string;
   let authPath: string;
+  const originalEnv = {
+    GBRAIN_OPENCLAW_AUTH_PATH: process.env.GBRAIN_OPENCLAW_AUTH_PATH,
+    OPENCLAW_AUTH_PATH: process.env.OPENCLAW_AUTH_PATH,
+  };
 
   beforeEach(() => {
     resetGateway();
     tempDir = mkdtempSync(join(tmpdir(), 'gbrain-auth-'));
     mkdirSync(join(tempDir, '.openclaw'), { recursive: true });
     authPath = join(tempDir, '.openclaw', 'auth.json');
+    delete process.env.GBRAIN_OPENCLAW_AUTH_PATH;
+    delete process.env.OPENCLAW_AUTH_PATH;
   });
 
   afterEach(() => {
+    process.env.GBRAIN_OPENCLAW_AUTH_PATH = originalEnv.GBRAIN_OPENCLAW_AUTH_PATH;
+    process.env.OPENCLAW_AUTH_PATH = originalEnv.OPENCLAW_AUTH_PATH;
     rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -55,6 +63,27 @@ describe('provider auth resolver', () => {
     expect(resolution.source).toBe('openclaw-codex');
     expect(resolution.credentialKey).toBe('OPENAI_API_KEY');
     expect(resolution.value).toBe('oc-secret');
+  });
+
+  test('env override path resolves openclaw auth record', () => {
+    writeFileSync(authPath, JSON.stringify({ profiles: { 'openclaw-codex': { OPENAI_API_KEY: 'oc-secret' } } }));
+    process.env.GBRAIN_OPENCLAW_AUTH_PATH = authPath;
+    const resolution = resolveProviderAuth(openai, config({
+      env: {},
+      provider_auth: { openai: { prefer: 'openclaw-codex' } },
+    }));
+    expect(resolution.source).toBe('openclaw-codex');
+    expect(resolution.value).toBe('oc-secret');
+  });
+
+  test('malformed openclaw auth file reports missing without leaking raw content', () => {
+    writeFileSync(authPath, '{not json');
+    const resolution = resolveProviderAuth(openai, config({
+      env: {},
+      provider_auth: { openai: { prefer: 'openclaw-codex', openclawAuthPath: authPath } },
+    }));
+    expect(resolution.source).toBe('missing');
+    expect(JSON.stringify(redactAuthResolution(resolution))).not.toContain('{not json');
   });
 
   test('redaction omits token values', () => {

--- a/test/commands/providers.test.ts
+++ b/test/commands/providers.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
+
+const configureGatewayMock = mock(() => {});
+const embedOneMock = mock(async () => new Array(1536).fill(0));
+const isAvailableMock = mock(() => true);
+const probeOllamaMock = mock(async () => ({ reachable: false, models_endpoint_valid: false }));
+const probeLMStudioMock = mock(async () => ({ reachable: false, models_endpoint_valid: false }));
+const loadConfigMock = mock(() => ({
+  embedding_model: 'openai:text-embedding-3-large',
+  embedding_dimensions: 1536,
+  expansion_model: 'anthropic:claude-haiku-4-5-20251001',
+  provider_auth: { openai: { prefer: 'openclaw-codex', profile: 'openclaw-codex' } },
+}));
+const resolveProviderAuthMock = mock((recipe: { id: string }) => {
+  if (recipe.id === 'openai') {
+    return {
+      source: 'openclaw-codex',
+      isConfigured: true,
+      credentialKey: 'OPENAI_API_KEY',
+      meta: { profile: 'openclaw-codex' },
+    };
+  }
+  if (recipe.id === 'anthropic') {
+    return {
+      source: 'missing',
+      isConfigured: false,
+      missingReason: 'Missing ANTHROPIC_API_KEY.',
+      meta: { mode: 'env' },
+    };
+  }
+  return {
+    source: 'missing',
+    isConfigured: false,
+    missingReason: 'missing',
+    meta: { mode: 'env' },
+  };
+});
+
+mock.module('../../src/core/ai/gateway.ts', () => ({
+  configureGateway: configureGatewayMock,
+  embedOne: embedOneMock,
+  isAvailable: isAvailableMock,
+}));
+
+mock.module('../../src/core/ai/probes.ts', () => ({
+  probeOllama: probeOllamaMock,
+  probeLMStudio: probeLMStudioMock,
+}));
+
+mock.module('../../src/core/config.ts', () => ({
+  loadConfig: loadConfigMock,
+}));
+
+mock.module('../../src/core/ai/auth.ts', () => ({
+  resolveProviderAuth: resolveProviderAuthMock,
+  redactAuthResolution: (resolution: unknown) => resolution,
+}));
+
+describe('providers command auth hardening', () => {
+  const logSpy = spyOn(console, 'log').mockImplementation(() => {});
+  const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+  beforeEach(() => {
+    configureGatewayMock.mockClear();
+    embedOneMock.mockClear();
+    isAvailableMock.mockClear();
+    probeOllamaMock.mockClear();
+    probeLMStudioMock.mockClear();
+    loadConfigMock.mockClear();
+    resolveProviderAuthMock.mockClear();
+    logSpy.mockClear();
+    errorSpy.mockClear();
+    isAvailableMock.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  test('providers test --model preserves provider_auth while overriding only model', async () => {
+    const { runProviders } = await import('../../src/commands/providers.ts');
+    await runProviders('test', ['--model', 'openai:text-embedding-3-small']);
+
+    expect(configureGatewayMock).toHaveBeenCalledTimes(2);
+    const overrideArgs = configureGatewayMock.mock.calls[1] as unknown[] | undefined;
+    const overrideCall = overrideArgs?.[0] as Record<string, unknown> | undefined;
+    expect(overrideCall).toMatchObject({
+      embedding_model: 'openai:text-embedding-3-small',
+      provider_auth: { openai: { prefer: 'openclaw-codex', profile: 'openclaw-codex' } },
+    });
+  });
+
+  test('providers explain recommends openai when auth comes from openclaw profile', async () => {
+    const { runProviders } = await import('../../src/commands/providers.ts');
+    await runProviders('explain', []);
+
+    const output = logSpy.mock.calls.map(call => String(call[0])).join('\n');
+    expect(output).toContain('Recommended: openai:text-embedding-3-large');
+    expect(output).toContain('OpenAI auth resolved via openclaw-codex');
+    expect(output).not.toContain('oc-secret');
+  });
+});


### PR DESCRIPTION
Fixes #2

## Changes
- thread provider_auth through cli/init/providers test override so fresh init + provider smoke tests keep explicit OpenClaw auth selection
- make providers explain/recommendation auth-source aware so integrated OpenClaw Codex OAuth setups recommend the working path without requiring OPENAI_API_KEY
- centralize OpenClaw auth path resolution with env override support and malformed-profile-safe handling
- add regression tests for auth resolver path overrides and providers command integration

## Testing
- bun run typecheck
- bun test test/ai/auth.test.ts test/commands/providers.test.ts test/ai/gateway.test.ts --timeout=60000

## Notes for reviewer
- optimized for the integrated fresh-init customer path primary operator called out; legacy obscure modes were left untouched unless they blocked that flow
- explicit cleanup/verification expectation: if an old broken brain config is in the way, re-run fresh init after clearing the stale gbrain config/auth path intentionally rather than relying on partial migration behavior