### PR TITLE
fix: harden provider init flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,13 @@ the full doc map, use `llms.txt` at the same URL root.
 
 ```bash
 git clone https://github.com/garrytan/gbrain.git && cd gbrain && bun install && bun link
-gbrain init                     # local brain, ready in 2 seconds
-gbrain import ~/notes/          # index your markdown
+gbrain init --pglite --model voyage   # fresh local brain with Voyage 1024d embeddings
+gbrain providers test --model voyage:voyage-3-large
+gbrain import ~/notes/                # index your markdown
 gbrain query "what themes show up across my notes?"
 ```
+
+If you already have a populated brain, the safest production path for provider/dimension changes is a fresh init plus explicit migration/backup. Preserve the old brain first with `gbrain migrate --to supabase|pglite` or a file backup/export, then re-init against an empty target.
 
 **Do NOT use `bun install -g github:garrytan/gbrain`.** Bun blocks the top-level
 postinstall hook on global installs, so schema migrations never run and the CLI

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -209,10 +209,11 @@ async function initPGLite(opts: {
       console.log(`${stats.page_count} pages. Engine: PGLite (local Postgres).`);
       if (stats.page_count > 0) {
         console.log('');
-        console.log('Existing brain detected. To wire up the v0.10.3 knowledge graph:');
-        console.log('  gbrain extract links --source db        (typed link backfill)');
-        console.log('  gbrain extract timeline --source db     (structured timeline backfill)');
-        console.log('  gbrain stats                            (verify links > 0)');
+        console.log('Existing brain detected. Fresh init is the supported production path for provider-base setup.');
+        console.log('Before switching providers or dimensions, preserve this brain explicitly:');
+        console.log('  gbrain migrate --to supabase            (copy into a fresh Postgres brain)');
+        console.log('  cp ~/.gbrain/brain.pglite ~/.gbrain/brain.pglite.bak   (quick local backup)');
+        console.log('Then re-run `gbrain init --pglite --model <provider>` on an empty brain.');
       } else {
         console.log('Next: gbrain import <dir>');
       }
@@ -313,10 +314,11 @@ async function initPostgres(opts: {
       console.log(`\nBrain ready. ${stats.page_count} pages. Engine: Postgres (Supabase).`);
       if (stats.page_count > 0) {
         console.log('');
-        console.log('Existing brain detected. To wire up the v0.10.3 knowledge graph:');
-        console.log('  gbrain extract links --source db        (typed link backfill)');
-        console.log('  gbrain extract timeline --source db     (structured timeline backfill)');
-        console.log('  gbrain stats                            (verify links > 0)');
+        console.log('Existing brain detected. Fresh init is the supported production path for provider-base setup.');
+        console.log('Before switching providers or dimensions, preserve this brain explicitly:');
+        console.log('  gbrain migrate --to pglite --force --path ~/.gbrain/brain.pglite   (copy into a fresh local brain)');
+        console.log('  gbrain export --dir ./gbrain-export     (portable markdown export)');
+        console.log('Then point init at a clean Postgres target and re-import if needed.');
       } else {
         console.log('Next: gbrain import <dir>');
       }

--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -116,9 +116,12 @@ async function runTest(args: string[]): Promise<void> {
     const modelId = modelParts.join(':');
     const recipe = getRecipe(providerId);
     const dims = recipe?.touchpoints.embedding?.default_dims ?? 1536;
+    const config = loadConfig();
     configureGateway({
       embedding_model: modelArg,
       embedding_dimensions: dims,
+      expansion_model: config?.expansion_model,
+      base_urls: config?.provider_base_urls,
       env: { ...process.env },
     });
   }

--- a/src/core/ai/dims.ts
+++ b/src/core/ai/dims.ts
@@ -15,8 +15,9 @@ import type { Implementation } from './types.ts';
  * Build the providerOptions blob for embedMany() that pins output dimensions.
  *
  * Matryoshka providers (OpenAI text-embedding-3, Gemini embedding-001) can be
- * asked to return reduced-dim vectors. openai-compatible + anthropic do not
- * take a dimension parameter.
+ * asked to return reduced-dim vectors. Anthropic does not take a dimension
+ * parameter. Most openai-compatible providers do not either, but Voyage's
+ * OpenAI-compatible embeddings endpoint accepts `output_dimension`.
  */
 export function dimsProviderOptions(
   implementation: Implementation,
@@ -41,8 +42,12 @@ export function dimsProviderOptions(
       // Anthropic has no embedding model.
       return undefined;
     case 'openai-compatible':
-      // Ollama, LM Studio, vLLM, Voyage-compat, LiteLLM: no standard dim param.
-      // Users pick a model that natively outputs the dims they want.
+      // Most openai-compatible providers (Ollama, LM Studio, vLLM, LiteLLM)
+      // do not expose a standard dimensions knob. Voyage's compat endpoint is
+      // the exception: it accepts output_dimension and defaults to 1024 dims.
+      if (modelId.startsWith('voyage-')) {
+        return { openaiCompatible: { output_dimension: dims } };
+      }
       return undefined;
   }
 }

--- a/test/ai/gateway.test.ts
+++ b/test/ai/gateway.test.ts
@@ -151,8 +151,13 @@ describe('dims.dimsProviderOptions', () => {
     expect(opts).toBeUndefined();
   });
 
-  test('openai-compatible returns undefined (no standard dim param)', () => {
+  test('openai-compatible returns undefined for providers without a dim param', () => {
     const opts = dimsProviderOptions('openai-compatible', 'nomic-embed-text', 768);
     expect(opts).toBeUndefined();
+  });
+
+  test('Voyage openai-compatible returns output_dimension', () => {
+    const opts = dimsProviderOptions('openai-compatible', 'voyage-3-large', 1024);
+    expect(opts).toEqual({ openaiCompatible: { output_dimension: 1024 } });
   });
 });

--- a/test/import-file.test.ts
+++ b/test/import-file.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { describe, test, expect, beforeAll, afterAll, mock } from 'bun:test';
 import { writeFileSync, mkdirSync, rmSync, symlinkSync } from 'fs';
 import { join } from 'path';
 import { importFile, importFromContent } from '../src/core/import-file.ts';
@@ -405,6 +405,29 @@ ${longText}
       for (let i = 0; i < chunks.length; i++) {
         expect(chunks[i].chunk_index).toBe(i);
       }
+    }
+  });
+
+  test('code-file import fails closed when embedding fails', async () => {
+    const restore = mock.module('../src/core/embedding.ts', async () => {
+      const actual = await import('../src/core/embedding.ts');
+      return {
+        ...actual,
+        embedBatch: mock(async () => {
+          throw new Error('boom');
+        }),
+      };
+    });
+
+    try {
+      const { importCodeFile } = await import('../src/core/import-file.ts');
+      const engine = mockEngine();
+      await expect(importCodeFile(engine, 'src/example.ts', 'export const x = 1;')).rejects.toThrow('boom');
+      const calls = (engine as any)._calls;
+      expect(calls.find((c: any) => c.method === 'putPage')).toBeUndefined();
+      expect(calls.find((c: any) => c.method === 'upsertChunks')).toBeUndefined();
+    } finally {
+      await restore;
     }
   });
 });


### PR DESCRIPTION
Fixes #1

## Changes
- make Voyage openai-compatible embeddings pass `output_dimension` so fresh init + provider test align on 1024d
- add regression coverage that code-file imports fail closed on embedding failure and provider dim helpers cover Voyage
- preserve configured base URLs/expansion config in `gbrain providers test --model ...`
- update init/readme messaging to prefer fresh init plus explicit migrate/backup when switching providers/dimensions on populated brains

## Testing
- `bun run typecheck`
- `bun test test/import-file.test.ts --timeout=60000`
- `bun test test/ai/gateway.test.ts --timeout=60000`

## Known limitations
- I did not run `gbrain providers test --model voyage:voyage-3-large` end-to-end because `VOYAGE_API_KEY` is not available in this worktree/session.
- Focus is the fresh-init production path; legacy populated-brain provider swaps now point users to explicit migrate/backup flows instead of trying to auto-heal every old state.
