### PR TITLE
feat: add normalized media extraction boundary

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -443,6 +443,11 @@ async function handleCliOnly(command: string, args: string[]) {
         await runImport(engine, args);
         break;
       }
+      case 'import-media': {
+        const { runImportMedia } = await import('./commands/import-media.ts');
+        await runImportMedia(engine, args);
+        break;
+      }
       case 'export': {
         const { runExport } = await import('./commands/export.ts');
         await runExport(engine, args);
@@ -654,6 +659,8 @@ SEARCH
 
 IMPORT/EXPORT
   import <dir> [--no-embed]          Import markdown directory
+  import-media --slug <slug> --content-file <md> --extraction <json>
+                                     Import normalized media evidence into a page
   sync [--repo <path>] [flags]       Git-to-brain incremental sync
   sync --watch [--interval N]        Continuous sync (loops until stopped)
   sync --install-cron                Install persistent sync daemon

--- a/src/commands/import-media.ts
+++ b/src/commands/import-media.ts
@@ -1,0 +1,46 @@
+import { existsSync, readFileSync } from 'fs';
+import type { BrainEngine } from '../core/engine.ts';
+import { importMediaEvidence } from '../core/import-file.ts';
+import { normalizeMediaExtraction, mediaExtractionToEvidence } from '../core/media-extraction.ts';
+
+function usage(): never {
+  console.error('Usage: gbrain import-media --slug <slug> --content-file <file.md> --extraction <file.json> [--source <name>] [--raw-data-source <name>] [--no-embed]');
+  process.exit(1);
+}
+
+function getFlag(args: string[], name: string): string | undefined {
+  const idx = args.indexOf(name);
+  return idx !== -1 ? args[idx + 1] : undefined;
+}
+
+export async function runImportMedia(engine: BrainEngine, args: string[]) {
+  const slug = getFlag(args, '--slug');
+  const contentFile = getFlag(args, '--content-file');
+  const extractionFile = getFlag(args, '--extraction');
+  const source = getFlag(args, '--source');
+  const rawDataSource = getFlag(args, '--raw-data-source');
+  const noEmbed = args.includes('--no-embed');
+
+  if (!slug || !contentFile || !extractionFile) usage();
+  if (!existsSync(contentFile) || !existsSync(extractionFile)) usage();
+
+  const content = readFileSync(contentFile, 'utf-8');
+  const extractionJson = JSON.parse(readFileSync(extractionFile, 'utf-8')) as unknown;
+  const extraction = normalizeMediaExtraction(extractionJson);
+  const evidence = mediaExtractionToEvidence(extraction);
+
+  const result = await importMediaEvidence(engine, slug, content, extraction, {
+    noEmbed,
+    source,
+    rawDataSource,
+  });
+
+  console.log(JSON.stringify({
+    status: result.status,
+    slug: result.slug,
+    chunks: result.chunks,
+    raw_data_source: rawDataSource ?? source ?? 'media-extraction',
+    segment_count: evidence.segments.length,
+    evidence_text_length: evidence.text.length,
+  }, null, 2));
+}

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -11,6 +11,7 @@ import { extractCodeRefs } from './link-extraction.ts';
 import { embedBatch } from './embedding.ts';
 import { slugifyPath, slugifyCodePath, isCodeFilePath } from './sync.ts';
 import type { ChunkInput, PageType } from './types.ts';
+import { buildMediaEvidenceRawData, type MediaEvidence } from './media-extraction.ts';
 
 /**
  * v0.20.0 Cathedral II Layer 8 D2 — markdown fence extraction helper.
@@ -165,6 +166,11 @@ export interface ImportResult {
    * Absent only on status='error' (early payload-size rejection).
    */
   parsedPage?: ParsedPage;
+}
+
+export interface ImportMediaEvidenceOptions {
+  source?: string;
+  rawDataSource?: string;
 }
 
 const MAX_FILE_SIZE = 5_000_000; // 5MB
@@ -400,6 +406,20 @@ export async function importFromFile(
  * Uses tree-sitter code chunker for semantic splitting.
  * Page type is 'code', slug includes file extension.
  */
+export async function importMediaEvidence(
+  engine: BrainEngine,
+  slug: string,
+  content: string,
+  extraction: unknown,
+  opts: { noEmbed?: boolean } & ImportMediaEvidenceOptions = {},
+): Promise<ImportResult> {
+  const evidence: MediaEvidence = buildMediaEvidenceRawData(extraction);
+  const result = await importFromContent(engine, slug, content, { noEmbed: opts.noEmbed });
+  if (result.status !== 'imported' && result.status !== 'skipped') return result;
+  await engine.putRawData(slug, opts.rawDataSource ?? opts.source ?? 'media-extraction', evidence as unknown as object);
+  return result;
+}
+
 export async function importCodeFile(
   engine: BrainEngine,
   relativePath: string,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,4 +1,5 @@
 export type { BrainEngine } from './engine.ts';
 export { PostgresEngine } from './postgres-engine.ts';
 export * from './types.ts';
+export * from './media-extraction.ts';
 export { parseMarkdown, serializeMarkdown, splitBody } from './markdown.ts';

--- a/src/core/media-extraction.ts
+++ b/src/core/media-extraction.ts
@@ -1,0 +1,256 @@
+export type MediaExtractionKind = 'image' | 'pdf' | 'video' | 'audio';
+
+export type MediaSegmentKind = 'asset' | 'page' | 'frame' | 'transcript_segment' | 'audio_segment';
+
+export interface MediaLocator {
+  page?: number;
+  pageLabel?: string;
+  frame?: number;
+  timecode?: string;
+  startMs?: number;
+  endMs?: number;
+  bbox?: [number, number, number, number];
+  timestamp?: string;
+}
+
+export interface MediaEntity {
+  text: string;
+  type?: string;
+  confidence?: number;
+}
+
+export interface MediaTag {
+  value: string;
+  confidence?: number;
+}
+
+export interface MediaMatchReason {
+  kind: 'ocr' | 'caption' | 'summary' | 'transcript' | 'entity' | 'tag' | 'visual' | 'metadata' | 'other';
+  detail: string;
+  confidence?: number;
+}
+
+export interface MediaExtractionSegment {
+  id: string;
+  kind: MediaSegmentKind;
+  locator?: MediaLocator;
+  caption?: string;
+  summary?: string;
+  ocrText?: string;
+  transcriptText?: string;
+  entities?: MediaEntity[];
+  tags?: MediaTag[];
+  matchReasons?: MediaMatchReason[];
+  confidence?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface MediaExtraction {
+  schemaVersion: 'gbrain.media-extraction.v1';
+  kind: MediaExtractionKind;
+  sourceRef?: string;
+  title?: string;
+  summary?: string;
+  caption?: string;
+  ocrText?: string;
+  transcriptText?: string;
+  segments: MediaExtractionSegment[];
+  entities?: MediaEntity[];
+  tags?: MediaTag[];
+  matchReasons?: MediaMatchReason[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface MediaEvidence {
+  schemaVersion: 'gbrain.media-evidence.v1';
+  kind: MediaExtractionKind;
+  sourceRef?: string;
+  text: string;
+  segments: MediaExtractionSegment[];
+  entities: MediaEntity[];
+  tags: MediaTag[];
+  matchReasons: MediaMatchReason[];
+  metadata?: Record<string, unknown>;
+}
+
+function normalizeString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeConfidence(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;
+  if (value < 0 || value > 1) return undefined;
+  return value;
+}
+
+function normalizeLocator(value: unknown): MediaLocator | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const loc = value as Record<string, unknown>;
+  const bbox = Array.isArray(loc.bbox) && loc.bbox.length === 4 && loc.bbox.every(n => typeof n === 'number' && Number.isFinite(n))
+    ? [loc.bbox[0] as number, loc.bbox[1] as number, loc.bbox[2] as number, loc.bbox[3] as number] as [number, number, number, number]
+    : undefined;
+  const out: MediaLocator = {
+    page: typeof loc.page === 'number' && Number.isFinite(loc.page) ? loc.page : undefined,
+    pageLabel: normalizeString(loc.pageLabel),
+    frame: typeof loc.frame === 'number' && Number.isFinite(loc.frame) ? loc.frame : undefined,
+    timecode: normalizeString(loc.timecode),
+    startMs: typeof loc.startMs === 'number' && Number.isFinite(loc.startMs) ? loc.startMs : undefined,
+    endMs: typeof loc.endMs === 'number' && Number.isFinite(loc.endMs) ? loc.endMs : undefined,
+    bbox,
+    timestamp: normalizeString(loc.timestamp),
+  };
+  return Object.values(out).some(v => v !== undefined) ? out : undefined;
+}
+
+function normalizeEntities(values: unknown): MediaEntity[] | undefined {
+  if (!Array.isArray(values)) return undefined;
+  const out: MediaEntity[] = [];
+  for (const value of values) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+    const row = value as Record<string, unknown>;
+    const text = normalizeString(row.text);
+    if (!text) continue;
+    const entity: MediaEntity = { text };
+    const type = normalizeString(row.type);
+    const confidence = normalizeConfidence(row.confidence);
+    if (type) entity.type = type;
+    if (confidence !== undefined) entity.confidence = confidence;
+    out.push(entity);
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+function normalizeTags(values: unknown): MediaTag[] | undefined {
+  if (!Array.isArray(values)) return undefined;
+  const out: MediaTag[] = [];
+  for (const value of values) {
+    if (typeof value === 'string') {
+      const normalized = normalizeString(value);
+      if (normalized) out.push({ value: normalized });
+      continue;
+    }
+    if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+    const row = value as Record<string, unknown>;
+    const tag = normalizeString(row.value);
+    if (!tag) continue;
+    const normalizedTag: MediaTag = { value: tag };
+    const confidence = normalizeConfidence(row.confidence);
+    if (confidence !== undefined) normalizedTag.confidence = confidence;
+    out.push(normalizedTag);
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+function normalizeMatchReasons(values: unknown): MediaMatchReason[] | undefined {
+  if (!Array.isArray(values)) return undefined;
+  const out: MediaMatchReason[] = [];
+  for (const value of values) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+    const row = value as Record<string, unknown>;
+    const kind = normalizeString(row.kind) as MediaMatchReason['kind'] | undefined;
+    const detail = normalizeString(row.detail);
+    if (!kind || !detail) continue;
+    const reason: MediaMatchReason = { kind, detail };
+    const confidence = normalizeConfidence(row.confidence);
+    if (confidence !== undefined) reason.confidence = confidence;
+    out.push(reason);
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+function normalizeSegment(value: unknown, index: number): MediaExtractionSegment {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Media extraction segment at index ${index} must be an object`);
+  }
+  const row = value as Record<string, unknown>;
+  const id = normalizeString(row.id) ?? `segment-${index}`;
+  const kind = normalizeString(row.kind) as MediaSegmentKind | undefined;
+  if (!kind) throw new Error(`Media extraction segment ${id} is missing kind`);
+  return {
+    id,
+    kind,
+    locator: normalizeLocator(row.locator),
+    caption: normalizeString(row.caption),
+    summary: normalizeString(row.summary),
+    ocrText: normalizeString(row.ocrText),
+    transcriptText: normalizeString(row.transcriptText),
+    entities: normalizeEntities(row.entities),
+    tags: normalizeTags(row.tags),
+    matchReasons: normalizeMatchReasons(row.matchReasons),
+    confidence: normalizeConfidence(row.confidence),
+    metadata: row.metadata && typeof row.metadata === 'object' && !Array.isArray(row.metadata) ? row.metadata as Record<string, unknown> : undefined,
+  };
+}
+
+export function normalizeMediaExtraction(input: unknown): MediaExtraction {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('Media extraction payload must be an object');
+  }
+  const row = input as Record<string, unknown>;
+  const kind = normalizeString(row.kind) as MediaExtractionKind | undefined;
+  if (!kind) throw new Error('Media extraction payload is missing kind');
+  const segmentsInput = row.segments;
+  if (!Array.isArray(segmentsInput) || segmentsInput.length === 0) {
+    throw new Error('Media extraction payload must include at least one segment');
+  }
+  return {
+    schemaVersion: 'gbrain.media-extraction.v1',
+    kind,
+    sourceRef: normalizeString(row.sourceRef),
+    title: normalizeString(row.title),
+    summary: normalizeString(row.summary),
+    caption: normalizeString(row.caption),
+    ocrText: normalizeString(row.ocrText),
+    transcriptText: normalizeString(row.transcriptText),
+    segments: segmentsInput.map((segment, index) => normalizeSegment(segment, index)),
+    entities: normalizeEntities(row.entities),
+    tags: normalizeTags(row.tags),
+    matchReasons: normalizeMatchReasons(row.matchReasons),
+    metadata: row.metadata && typeof row.metadata === 'object' && !Array.isArray(row.metadata) ? row.metadata as Record<string, unknown> : undefined,
+  };
+}
+
+function pushText(parts: string[], value: string | undefined) {
+  if (value) parts.push(value);
+}
+
+export function mediaExtractionToEvidence(extraction: MediaExtraction): MediaEvidence {
+  const parts: string[] = [];
+  pushText(parts, extraction.title);
+  pushText(parts, extraction.summary);
+  pushText(parts, extraction.caption);
+  pushText(parts, extraction.ocrText);
+  pushText(parts, extraction.transcriptText);
+
+  const entities: MediaEntity[] = [...(extraction.entities ?? [])];
+  const tags: MediaTag[] = [...(extraction.tags ?? [])];
+  const matchReasons: MediaMatchReason[] = [...(extraction.matchReasons ?? [])];
+
+  for (const segment of extraction.segments) {
+    pushText(parts, segment.caption);
+    pushText(parts, segment.summary);
+    pushText(parts, segment.ocrText);
+    pushText(parts, segment.transcriptText);
+    if (segment.entities) entities.push(...segment.entities);
+    if (segment.tags) tags.push(...segment.tags);
+    if (segment.matchReasons) matchReasons.push(...segment.matchReasons);
+  }
+
+  return {
+    schemaVersion: 'gbrain.media-evidence.v1',
+    kind: extraction.kind,
+    sourceRef: extraction.sourceRef,
+    text: parts.join('\n\n').trim(),
+    segments: extraction.segments,
+    entities,
+    tags,
+    matchReasons,
+    metadata: extraction.metadata,
+  };
+}
+
+export function buildMediaEvidenceRawData(input: unknown): MediaEvidence {
+  return mediaExtractionToEvidence(normalizeMediaExtraction(input));
+}

--- a/test/fixtures/media-extraction-image.json
+++ b/test/fixtures/media-extraction-image.json
@@ -1,0 +1,27 @@
+{
+  "kind": "image",
+  "sourceRef": "screenshots/stripe-error-login.png",
+  "title": "Stripe login error screenshot",
+  "caption": "Login form showing a Stripe API key error banner",
+  "ocrText": "Stripe API key invalid. Please update your environment variables.",
+  "tags": ["stripe", "error", "login"],
+  "matchReasons": [
+    { "kind": "ocr", "detail": "Detected API key error text", "confidence": 0.97 }
+  ],
+  "segments": [
+    {
+      "id": "image-root",
+      "kind": "asset",
+      "caption": "Dashboard screenshot with error banner",
+      "ocrText": "Stripe API key invalid. Please update your environment variables.",
+      "locator": { "bbox": [0.1, 0.2, 0.8, 0.35] },
+      "entities": [
+        { "text": "Stripe", "type": "product", "confidence": 0.99 }
+      ],
+      "tags": ["dashboard"],
+      "matchReasons": [
+        { "kind": "caption", "detail": "Screenshot contains dashboard UI", "confidence": 0.82 }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/media-extraction-pdf.json
+++ b/test/fixtures/media-extraction-pdf.json
@@ -1,0 +1,29 @@
+{
+  "kind": "pdf",
+  "sourceRef": "docs/pricing-overview.pdf",
+  "title": "Pricing overview PDF",
+  "summary": "Three pricing tiers with enterprise add-ons.",
+  "segments": [
+    {
+      "id": "page-1",
+      "kind": "page",
+      "locator": { "page": 1, "pageLabel": "1" },
+      "summary": "Cover page summarizing pricing tiers",
+      "ocrText": "Starter, Growth, Enterprise",
+      "tags": ["pricing", "tiers"],
+      "matchReasons": [
+        { "kind": "ocr", "detail": "Page lists pricing tiers", "confidence": 0.95 }
+      ]
+    },
+    {
+      "id": "page-2",
+      "kind": "page",
+      "locator": { "page": 2, "pageLabel": "2" },
+      "summary": "Enterprise add-ons and support levels",
+      "ocrText": "Dedicated support, SSO, audit logs",
+      "entities": [
+        { "text": "SSO", "type": "feature", "confidence": 0.88 }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/media-extraction-video.json
+++ b/test/fixtures/media-extraction-video.json
@@ -1,0 +1,29 @@
+{
+  "kind": "video",
+  "sourceRef": "recordings/login-demo.mp4",
+  "title": "Login demo recording",
+  "summary": "Walkthrough of a login failure and fix.",
+  "transcriptText": "At 12 seconds we hit the invalid API key error. At 26 seconds we confirm the env var fix.",
+  "segments": [
+    {
+      "id": "frame-12s",
+      "kind": "frame",
+      "locator": { "frame": 360, "timecode": "00:00:12.000", "startMs": 12000, "endMs": 12000 },
+      "caption": "Login form with red invalid API key error",
+      "ocrText": "Invalid API key",
+      "matchReasons": [
+        { "kind": "visual", "detail": "Error banner visible in frame", "confidence": 0.86 }
+      ]
+    },
+    {
+      "id": "transcript-26s",
+      "kind": "transcript_segment",
+      "locator": { "timecode": "00:00:26.000", "startMs": 26000, "endMs": 31000 },
+      "transcriptText": "We fixed the issue by rotating the Stripe API key and reloading the app.",
+      "entities": [
+        { "text": "Stripe API key", "type": "secret", "confidence": 0.91 }
+      ],
+      "tags": ["fix"]
+    }
+  ]
+}

--- a/test/media-extraction.test.ts
+++ b/test/media-extraction.test.ts
@@ -1,0 +1,88 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { importMediaEvidence } from '../src/core/import-file.ts';
+import { mediaExtractionToEvidence, normalizeMediaExtraction } from '../src/core/media-extraction.ts';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { runImportMedia } from '../src/commands/import-media.ts';
+
+const FIXTURES = join(import.meta.dir, 'fixtures');
+
+describe('media extraction normalization', () => {
+  test('normalizes screenshot/pdf/video fixtures into evidence text', () => {
+    for (const name of ['media-extraction-image.json', 'media-extraction-pdf.json', 'media-extraction-video.json']) {
+      const raw = JSON.parse(readFileSync(join(FIXTURES, name), 'utf-8'));
+      const extraction = normalizeMediaExtraction(raw);
+      const evidence = mediaExtractionToEvidence(extraction);
+      expect(extraction.schemaVersion).toBe('gbrain.media-extraction.v1');
+      expect(evidence.schemaVersion).toBe('gbrain.media-evidence.v1');
+      expect(evidence.segments.length).toBeGreaterThan(0);
+      expect(evidence.text.length).toBeGreaterThan(10);
+    }
+  });
+
+  test('rejects payloads without segments', () => {
+    expect(() => normalizeMediaExtraction({ kind: 'image', segments: [] })).toThrow(/at least one segment/);
+  });
+});
+
+describe('media evidence import', () => {
+  const engine = new PGLiteEngine();
+
+  beforeAll(async () => {
+    await engine.connect({});
+    await engine.initSchema();
+  });
+
+  beforeEach(async () => {
+    await resetPgliteState(engine);
+  });
+
+  afterAll(async () => {
+    await engine.disconnect();
+  });
+
+  test('stores normalized media evidence as raw_data sidecar', async () => {
+    const content = `---\ntype: media\ntitle: Stripe login screenshot\n---\n\nStripe login screenshot evidence.`;
+    const extraction = JSON.parse(readFileSync(join(FIXTURES, 'media-extraction-image.json'), 'utf-8'));
+
+    const result = await importMediaEvidence(engine, 'media/stripe-login-screenshot', content, extraction, { noEmbed: true });
+    expect(result.status).toBe('imported');
+
+    const rows = await engine.getRawData('media/stripe-login-screenshot', 'media-extraction');
+    expect(rows.length).toBe(1);
+    const data = rows[0]?.data as any;
+    expect(data.schemaVersion).toBe('gbrain.media-evidence.v1');
+    expect(data.kind).toBe('image');
+    expect(data.text).toContain('Stripe API key invalid');
+    expect(data.segments[0].locator.bbox).toEqual([0.1, 0.2, 0.8, 0.35]);
+  });
+
+  test('CLI import-media ingests extraction fixture', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-media-import-'));
+    const contentPath = join(dir, 'page.md');
+    const extractionPath = join(dir, 'evidence.json');
+    writeFileSync(contentPath, `---\ntype: media\ntitle: Demo video\n---\n\nDemo video evidence page.`);
+    writeFileSync(extractionPath, readFileSync(join(FIXTURES, 'media-extraction-video.json'), 'utf-8'));
+
+    try {
+      await runImportMedia(engine, [
+        '--slug', 'media/demo-video',
+        '--content-file', contentPath,
+        '--extraction', extractionPath,
+        '--no-embed',
+      ]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+
+    const raw = await engine.getRawData('media/demo-video', 'media-extraction');
+    expect(raw.length).toBe(1);
+    const data = raw[0]?.data as any;
+    expect(data.kind).toBe('video');
+    expect(data.segments.some((segment: any) => segment.kind === 'transcript_segment')).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #10

## Changes
- add normalized media extraction/media evidence types and evidence builder helpers
- add import-media CLI + import helper that stores media evidence in raw_data sidecars
- add image/pdf/video extraction fixtures and targeted tests for normalized ingestion

## Testing
- bun run typecheck
- bun test test/media-extraction.test.ts

## Notes for reviewer
- keeps extraction separate from storage/search; core only accepts normalized JSON payloads
- no new cloud extractor dependencies or OpenClaw tool coupling in core
