### PR TITLE
fix: bridge OpenClaw auth for embeddings

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ for (const op of operations) {
 }
 
 // CLI-only commands that bypass the operation layer
-const CLI_ONLY = new Set(['init', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'storage', 'repos', 'code-def', 'code-refs', 'reindex-code', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test']);
+const CLI_ONLY = new Set(['init', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'storage', 'repos', 'code-def', 'code-refs', 'reindex-code', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'providers', 'friction', 'claw-test']);
 
 async function main() {
   // Parse global flags (--quiet / --progress-json / --progress-interval)
@@ -434,6 +434,12 @@ async function handleCliOnly(command: string, args: string[]) {
     return;
   }
 
+  if (command === 'providers') {
+    const { runProviders } = await import('./commands/providers.ts');
+    await runProviders(args[0], args.slice(1));
+    return;
+  }
+
   // All remaining CLI-only commands need a DB connection
   const engine = await connectEngine();
   try {
@@ -640,6 +646,7 @@ SETUP
   check-update [--json]              Check for new versions
   doctor [--json] [--fast]            Health check (resolver, skills, pgvector, RLS, embeddings)
   integrations [subcommand]          Manage integration recipes (senses + reflexes)
+  providers list|explain             Inspect AI provider auth readiness
 
 PAGES
   get <slug>                         Read a page

--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -1,0 +1,96 @@
+import { loadConfig } from '../core/config.ts';
+import { redactAuthResolution, resolveOpenAIAuth } from '../core/ai/auth.ts';
+import { EMBEDDING_DIMENSIONS, EMBEDDING_MODEL } from '../core/embedding.ts';
+
+const SCHEMA_VERSION = 1;
+
+export async function runProviders(subcommand: string | undefined, args: string[]): Promise<void> {
+  switch (subcommand) {
+    case 'list':
+      return runList(args);
+    case 'explain':
+      return runExplain(args);
+    case undefined:
+    case '--help':
+    case '-h':
+      printHelp();
+      return;
+    default:
+      console.error(`Unknown providers subcommand: ${subcommand}`);
+      printHelp();
+      process.exit(1);
+  }
+}
+
+function printHelp(): void {
+  console.log(`gbrain providers — provider auth status
+
+USAGE
+  gbrain providers list            List provider readiness without secrets
+  gbrain providers explain [--json] Explain selected provider/auth source
+`);
+}
+
+function currentAuth() {
+  return resolveOpenAIAuth({ config: loadConfig() });
+}
+
+function runList(args: string[]): void {
+  const asJson = args.includes('--json') || args.includes('-j');
+  const auth = currentAuth();
+  const payload = {
+    schema_version: SCHEMA_VERSION,
+    providers: [
+      {
+        id: 'openai',
+        touchpoint: 'embedding',
+        model: EMBEDDING_MODEL,
+        dimensions: EMBEDDING_DIMENSIONS,
+        ready: auth.isConfigured,
+        auth: redactAuthResolution(auth),
+      },
+    ],
+  };
+
+  if (asJson) {
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  console.log('PROVIDER  TOUCHPOINT  MODEL                   DIMS  STATUS');
+  console.log('--------  ----------  ----------------------  ----  ----------------');
+  const row = payload.providers[0];
+  const status = row.ready ? `ready (${row.auth.source})` : `missing (${row.auth.missingReason ?? 'credentials'})`;
+  console.log(`${row.id.padEnd(8)}  ${row.touchpoint.padEnd(10)}  ${row.model.padEnd(22)}  ${String(row.dimensions).padEnd(4)}  ${status}`);
+}
+
+function runExplain(args: string[]): void {
+  const asJson = args.includes('--json') || args.includes('-j');
+  const auth = currentAuth();
+  const payload = {
+    schema_version: SCHEMA_VERSION,
+    selected: {
+      embedding: {
+        provider: 'openai',
+        model: EMBEDDING_MODEL,
+        dimensions: EMBEDDING_DIMENSIONS,
+        auth: redactAuthResolution(auth),
+        ready: auth.isConfigured,
+      },
+    },
+    notes: [
+      'Secrets are never printed. Values are only used in-process for OpenAI SDK calls.',
+      'Precedence: OPENAI_API_KEY env > gbrain config openai_api_key > OpenClaw auth profile bridge.',
+    ],
+  };
+
+  if (asJson) {
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  console.log(`Embedding provider: openai (${EMBEDDING_MODEL}, ${EMBEDDING_DIMENSIONS} dims)`);
+  console.log(`Auth source: ${auth.source}`);
+  console.log(`Status: ${auth.isConfigured ? 'ready' : auth.missingReason ?? 'missing credentials'}`);
+  if (auth.credentialKey) console.log(`Credential key: ${auth.credentialKey}`);
+}

--- a/src/core/ai/auth.ts
+++ b/src/core/ai/auth.ts
@@ -1,0 +1,226 @@
+import { existsSync, readFileSync } from 'fs';
+import { isAbsolute, join } from 'path';
+import { homedir } from 'os';
+import type { GBrainConfig } from '../config.ts';
+
+export type OpenAIAuthSource =
+  | 'env:OPENAI_API_KEY'
+  | 'config:openai_api_key'
+  | 'openclaw:auth-profiles'
+  | 'openclaw:legacy-auth-json'
+  | 'missing';
+
+export interface OpenAIAuthResolution {
+  source: OpenAIAuthSource;
+  isConfigured: boolean;
+  credentialKey?: string;
+  value?: string;
+  profileId?: string;
+  provider?: string;
+  missingReason?: string;
+}
+
+interface ResolveOpenAIAuthOptions {
+  env?: Record<string, string | undefined>;
+  config?: Pick<GBrainConfig, 'openai_api_key'> | null;
+}
+
+const OPENCLAW_PROFILE_PROVIDERS = new Set(['openai', 'openai-codex']);
+const LEGACY_PROFILE_IDS = ['openai', 'openai:default', 'openai-codex', 'openai-codex:default'];
+
+/**
+ * Resolve the credential gbrain should use for OpenAI-compatible calls.
+ *
+ * Precedence stays backward-compatible: explicit env wins, then gbrain config,
+ * then an OpenClaw-managed auth profile/bridge. This function never logs or
+ * returns secrets through redaction helpers.
+ */
+export function resolveOpenAIAuth(options: ResolveOpenAIAuthOptions = {}): OpenAIAuthResolution {
+  const env = options.env ?? process.env;
+  const config = options.config ?? null;
+
+  const envKey = env.OPENAI_API_KEY?.trim();
+  if (envKey) {
+    return {
+      source: 'env:OPENAI_API_KEY',
+      credentialKey: 'OPENAI_API_KEY',
+      value: envKey,
+      isConfigured: true,
+    };
+  }
+
+  const configKey = config?.openai_api_key?.trim();
+  if (configKey) {
+    return {
+      source: 'config:openai_api_key',
+      credentialKey: 'openai_api_key',
+      value: configKey,
+      isConfigured: true,
+    };
+  }
+
+  const bridged = resolveOpenClawProfileAuth(env);
+  if (bridged) return bridged;
+
+  return {
+    source: 'missing',
+    credentialKey: 'OPENAI_API_KEY',
+    isConfigured: false,
+    missingReason: 'Missing OPENAI_API_KEY, gbrain config openai_api_key, or readable OpenClaw OpenAI/Codex auth profile.',
+  };
+}
+
+export function getOpenAIApiKey(options: ResolveOpenAIAuthOptions = {}): string | undefined {
+  return resolveOpenAIAuth(options).value;
+}
+
+export function hasOpenAIAuth(options: ResolveOpenAIAuthOptions = {}): boolean {
+  return resolveOpenAIAuth(options).isConfigured;
+}
+
+export function redactAuthResolution(resolution: OpenAIAuthResolution): Omit<OpenAIAuthResolution, 'value'> {
+  const { value: _value, ...redacted } = resolution;
+  return redacted;
+}
+
+function resolveOpenClawProfileAuth(env: Record<string, string | undefined>): OpenAIAuthResolution | null {
+  for (const path of openClawAuthCandidatePaths(env)) {
+    const raw = readJson(path);
+    if (!raw) continue;
+
+    const fromStore = resolveFromAuthProfiles(raw, env);
+    if (fromStore) return fromStore;
+
+    const fromLegacy = resolveFromLegacyAuthJson(raw);
+    if (fromLegacy) return fromLegacy;
+  }
+  return null;
+}
+
+function openClawAuthCandidatePaths(env: Record<string, string | undefined>): string[] {
+  const explicit = [
+    env.GBRAIN_OPENCLAW_AUTH_PROFILES_PATH,
+    env.OPENCLAW_AUTH_PROFILES_PATH,
+    env.GBRAIN_OPENCLAW_AUTH_PATH,
+    env.OPENCLAW_AUTH_PATH,
+  ];
+  const explicitPaths = normalizeCandidatePaths(explicit);
+  if (explicitPaths.length > 0) return explicitPaths;
+
+  const candidates = [
+    env.OPENCLAW_AGENT_DIR ? join(env.OPENCLAW_AGENT_DIR, 'auth-profiles.json') : undefined,
+    env.PI_CODING_AGENT_DIR ? join(env.PI_CODING_AGENT_DIR, 'auth-profiles.json') : undefined,
+    join(homedir(), '.openclaw', 'state', 'agents', 'main', 'agent', 'auth-profiles.json'),
+    join(homedir(), '.openclaw', 'agents', 'main', 'agent', 'auth-profiles.json'),
+    join(homedir(), '.openclaw', 'auth.json'),
+  ];
+  return normalizeCandidatePaths(candidates);
+}
+
+function normalizeCandidatePaths(candidates: Array<string | undefined>): string[] {
+  return [...new Set(candidates.filter((p): p is string => typeof p === 'string' && p.trim().length > 0).map(expandUserPath))];
+}
+
+function expandUserPath(pathname: string): string {
+  const trimmed = pathname.trim();
+  if (trimmed === '~') return homedir();
+  if (trimmed.startsWith('~/')) return join(homedir(), trimmed.slice(2));
+  return isAbsolute(trimmed) ? trimmed : join(homedir(), trimmed);
+}
+
+function readJson(pathname: string): unknown | null {
+  try {
+    if (!existsSync(pathname)) return null;
+    return JSON.parse(readFileSync(pathname, 'utf-8')) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function resolveFromAuthProfiles(raw: unknown, env: Record<string, string | undefined>): OpenAIAuthResolution | null {
+  const root = asRecord(raw);
+  const profiles = asRecord(root?.profiles);
+  if (!profiles) return null;
+
+  const preferredIds = [...LEGACY_PROFILE_IDS, ...Object.keys(profiles)];
+  for (const profileId of [...new Set(preferredIds)]) {
+    const profile = asRecord(profiles[profileId]);
+    if (!profile) continue;
+    const provider = typeof profile.provider === 'string' ? profile.provider : undefined;
+    if (!provider || !OPENCLAW_PROFILE_PROVIDERS.has(provider)) continue;
+
+    const resolved = resolveProfileCredential(profile, env, provider);
+    if (!resolved) continue;
+
+    return {
+      source: 'openclaw:auth-profiles',
+      credentialKey: resolved.credentialKey,
+      value: resolved.value,
+      isConfigured: true,
+      profileId,
+      provider,
+    };
+  }
+  return null;
+}
+
+function resolveProfileCredential(profile: Record<string, unknown>, env: Record<string, string | undefined>, provider: string): { credentialKey: string; value: string } | null {
+  const keyRef = asRecord(profile.keyRef);
+  if (keyRef?.source === 'env' && typeof keyRef.id === 'string') {
+    const value = env[keyRef.id]?.trim();
+    if (value && isOpenAICompatibleCredential(provider, keyRef.id, 'keyRef')) return { credentialKey: keyRef.id, value };
+  }
+
+  const tokenRef = asRecord(profile.tokenRef);
+  if (tokenRef?.source === 'env' && typeof tokenRef.id === 'string') {
+    const value = env[tokenRef.id]?.trim();
+    if (value && isOpenAICompatibleCredential(provider, tokenRef.id, 'tokenRef')) return { credentialKey: tokenRef.id, value };
+  }
+
+  for (const field of ['key', 'token', 'access']) {
+    const value = profile[field];
+    if (typeof value === 'string' && value.trim() && isOpenAICompatibleCredential(provider, field, field)) {
+      return { credentialKey: field, value: value.trim() };
+    }
+  }
+
+  return null;
+}
+
+function isOpenAICompatibleCredential(provider: string, credentialKey: string, field: string): boolean {
+  if (provider === 'openai') return true;
+  // Codex OAuth access tokens are not the same thing as OpenAI embedding API
+  // keys. Accept only explicit OpenAI-compatible bridge material from a Codex
+  // profile; otherwise leave the provider missing instead of failing at call time.
+  if (provider === 'openai-codex') {
+    return field === 'key' || credentialKey === 'OPENAI_API_KEY';
+  }
+  return false;
+}
+
+function resolveFromLegacyAuthJson(raw: unknown): OpenAIAuthResolution | null {
+  const root = asRecord(raw);
+  if (!root) return null;
+
+  for (const id of LEGACY_PROFILE_IDS) {
+    const direct = asRecord(root[id]) ?? asRecord(asRecord(root.profiles)?.[id]);
+    if (!direct) continue;
+    for (const key of ['OPENAI_API_KEY']) {
+      const value = direct[key];
+      if (typeof value === 'string' && value.trim()) {
+        return {
+          source: 'openclaw:legacy-auth-json',
+          credentialKey: key,
+          value: value.trim(),
+          isConfigured: true,
+          profileId: id,
+        };
+      }
+    }
+  }
+  return null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' ? value as Record<string, unknown> : null;
+}

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -8,6 +8,8 @@
  */
 
 import OpenAI from 'openai';
+import { loadConfig } from './config.ts';
+import { resolveOpenAIAuth } from './ai/auth.ts';
 
 const MODEL = 'text-embedding-3-large';
 const DIMENSIONS = 1536;
@@ -18,12 +20,24 @@ const MAX_DELAY_MS = 120000;
 const BATCH_SIZE = 100;
 
 let client: OpenAI | null = null;
+let clientCredentialKey: string | null = null;
 
 function getClient(): OpenAI {
-  if (!client) {
-    client = new OpenAI();
+  const auth = resolveOpenAIAuth({ config: loadConfig() });
+  if (!auth.value) {
+    throw new Error(auth.missingReason ?? 'OpenAI credentials are not configured');
+  }
+  const key = `${auth.source}:${auth.credentialKey ?? ''}:${auth.profileId ?? ''}`;
+  if (!client || clientCredentialKey !== key) {
+    client = new OpenAI({ apiKey: auth.value });
+    clientCredentialKey = key;
   }
   return client;
+}
+
+export function resetEmbeddingClientForTests(): void {
+  client = null;
+  clientCredentialKey = null;
 }
 
 export async function embed(text: string): Promise<Float32Array> {

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -15,6 +15,7 @@ import { expandQuery } from './search/expansion.ts';
 import { dedupResults } from './search/dedup.ts';
 import { extractPageLinks, isAutoLinkEnabled, isAutoTimelineEnabled, parseTimelineEntries, makeResolver, type UnresolvedFrontmatterRef } from './link-extraction.ts';
 import * as db from './db.ts';
+import { hasOpenAIAuth } from './ai/auth.ts';
 
 // --- Types ---
 
@@ -326,11 +327,9 @@ const put_page: Operation = {
     }
 
     if (ctx.dryRun) return { dry_run: true, action: 'put_page', slug: p.slug };
-    // Skip embedding when no OpenAI key is configured. importFromContent's existing
-    // try/catch around embed only catches; without a key the OpenAI client would
-    // attempt 5 retries with exponential backoff (up to ~2 minutes total) before
-    // giving up. Detect early.
-    const noEmbed = !process.env.OPENAI_API_KEY;
+    // Skip embedding when no OpenAI-compatible credential is configured. This
+    // accepts env, gbrain config, and OpenClaw-managed auth profile bridges.
+    const noEmbed = !hasOpenAIAuth({ config: ctx.config });
     const result = await importFromContent(ctx.engine, slug, p.content as string, { noEmbed });
 
     // Auto-link post-hook: runs AFTER importFromContent (which is its own

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -13,6 +13,8 @@ import type { BrainEngine } from '../engine.ts';
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from '../engine.ts';
 import type { SearchResult, SearchOpts } from '../types.ts';
 import { embed } from '../embedding.ts';
+import { hasOpenAIAuth } from '../ai/auth.ts';
+import { loadConfig } from '../config.ts';
 import { dedupResults } from './dedup.ts';
 import { autoDetectDetail } from './intent.ts';
 import { expandAnchors, hydrateChunks } from './two-pass.ts';
@@ -85,8 +87,8 @@ export async function hybridSearch(
   // Run keyword search (always available, no API key needed)
   const keywordResults = await engine.searchKeyword(query, searchOpts);
 
-  // Skip vector search entirely if no OpenAI key is configured
-  if (!process.env.OPENAI_API_KEY) {
+  // Skip vector search entirely if no OpenAI-compatible credential is configured.
+  if (!hasOpenAIAuth({ config: loadConfig() })) {
     // Apply backlink boost in keyword-only path too. One getBacklinkCounts query
     // per search request; not N+1.
     if (keywordResults.length > 0) {

--- a/test/ai/auth.test.ts
+++ b/test/ai/auth.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { hasOpenAIAuth, redactAuthResolution, resolveOpenAIAuth } from '../../src/core/ai/auth.ts';
+
+const ENV_KEYS = [
+  'OPENAI_API_KEY',
+  'GBRAIN_OPENCLAW_AUTH_PROFILES_PATH',
+  'OPENCLAW_AUTH_PROFILES_PATH',
+  'GBRAIN_OPENCLAW_AUTH_PATH',
+  'OPENCLAW_AUTH_PATH',
+  'OPENCLAW_AGENT_DIR',
+  'PI_CODING_AGENT_DIR',
+  'PROFILE_KEY_ENV',
+];
+
+describe('OpenAI auth resolver', () => {
+  let tempDir: string;
+  let original: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    original = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+    for (const key of ENV_KEYS) delete process.env[key];
+    tempDir = mkdtempSync(join(tmpdir(), 'gbrain-openclaw-auth-'));
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = original[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('env OPENAI_API_KEY is highest priority', () => {
+    process.env.OPENAI_API_KEY = 'env-secret';
+    const resolution = resolveOpenAIAuth({ config: { openai_api_key: 'config-secret' } });
+    expect(resolution.source).toBe('env:OPENAI_API_KEY');
+    expect(resolution.value).toBe('env-secret');
+  });
+
+  test('gbrain config key is used when env is absent', () => {
+    const resolution = resolveOpenAIAuth({ config: { openai_api_key: 'config-secret' } });
+    expect(resolution.source).toBe('config:openai_api_key');
+    expect(resolution.value).toBe('config-secret');
+    expect(hasOpenAIAuth({ config: { openai_api_key: 'config-secret' } })).toBe(true);
+  });
+
+  test('OpenClaw auth-profiles api_key profile bridges OpenAI credentials', () => {
+    const path = join(tempDir, 'auth-profiles.json');
+    writeFileSync(path, JSON.stringify({
+      version: 1,
+      profiles: {
+        'openai:default': { type: 'api_key', provider: 'openai', key: 'profile-secret' },
+      },
+    }));
+    process.env.GBRAIN_OPENCLAW_AUTH_PROFILES_PATH = path;
+
+    const resolution = resolveOpenAIAuth({ config: null });
+    expect(resolution.source).toBe('openclaw:auth-profiles');
+    expect(resolution.profileId).toBe('openai:default');
+    expect(resolution.value).toBe('profile-secret');
+  });
+
+  test('OpenClaw env secret-ref profile resolves through host-provided env bridge', () => {
+    const path = join(tempDir, 'auth-profiles.json');
+    writeFileSync(path, JSON.stringify({
+      version: 1,
+      profiles: {
+        'openai:default': {
+          type: 'api_key',
+          provider: 'openai',
+          keyRef: { source: 'env', id: 'PROFILE_KEY_ENV' },
+        },
+      },
+    }));
+    process.env.GBRAIN_OPENCLAW_AUTH_PROFILES_PATH = path;
+    process.env.PROFILE_KEY_ENV = 'bridged-secret';
+
+    const resolution = resolveOpenAIAuth({ config: null });
+    expect(resolution.source).toBe('openclaw:auth-profiles');
+    expect(resolution.credentialKey).toBe('PROFILE_KEY_ENV');
+    expect(resolution.value).toBe('bridged-secret');
+  });
+
+  test('OpenClaw Codex OAuth token profile is not treated as an OpenAI embedding key', () => {
+    const path = join(tempDir, 'auth-profiles.json');
+    writeFileSync(path, JSON.stringify({
+      version: 1,
+      profiles: {
+        'openai-codex:default': { type: 'token', provider: 'openai-codex', token: 'codex-token' },
+      },
+    }));
+    process.env.GBRAIN_OPENCLAW_AUTH_PROFILES_PATH = path;
+
+    const resolution = resolveOpenAIAuth({ config: null });
+    expect(resolution.source).toBe('missing');
+    expect(JSON.stringify(redactAuthResolution(resolution))).not.toContain('codex-token');
+  });
+
+  test('OpenClaw Codex profile can carry an explicit OpenAI-compatible bridge key', () => {
+    const path = join(tempDir, 'auth-profiles.json');
+    writeFileSync(path, JSON.stringify({
+      version: 1,
+      profiles: {
+        'openai-codex:default': { type: 'api_key', provider: 'openai-codex', key: 'bridge-key' },
+      },
+    }));
+    process.env.GBRAIN_OPENCLAW_AUTH_PROFILES_PATH = path;
+
+    const resolution = resolveOpenAIAuth({ config: null });
+    expect(resolution.source).toBe('openclaw:auth-profiles');
+    expect(resolution.provider).toBe('openai-codex');
+    expect(resolution.value).toBe('bridge-key');
+  });
+
+  test('legacy auth.json profile shape is supported without leaking malformed content', () => {
+    const path = join(tempDir, 'auth.json');
+    writeFileSync(path, JSON.stringify({ profiles: { 'openai-codex': { OPENAI_API_KEY: 'legacy-secret' } } }));
+    process.env.GBRAIN_OPENCLAW_AUTH_PATH = path;
+
+    const resolution = resolveOpenAIAuth({ config: null });
+    expect(resolution.source).toBe('openclaw:legacy-auth-json');
+    expect(resolution.value).toBe('legacy-secret');
+
+    const redacted = redactAuthResolution(resolution);
+    expect(JSON.stringify(redacted)).not.toContain('legacy-secret');
+  });
+
+  test('missing or malformed profiles produce redacted missing result', () => {
+    const path = join(tempDir, 'auth-profiles.json');
+    writeFileSync(path, '{not json');
+    process.env.GBRAIN_OPENCLAW_AUTH_PROFILES_PATH = path;
+
+    const resolution = resolveOpenAIAuth({ config: null });
+    expect(resolution.source).toBe('missing');
+    expect(resolution.isConfigured).toBe(false);
+    expect(JSON.stringify(redactAuthResolution(resolution))).not.toContain('{not json');
+  });
+});

--- a/test/ai/providers.test.ts
+++ b/test/ai/providers.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { runProviders } from '../../src/commands/providers.ts';
+
+const ENV_KEYS = ['GBRAIN_HOME', 'OPENAI_API_KEY', 'GBRAIN_OPENCLAW_AUTH_PROFILES_PATH'];
+
+describe('providers command redaction', () => {
+  let tempDir: string;
+  let original: Record<string, string | undefined>;
+  let logs: string[];
+  let originalLog: typeof console.log;
+
+  beforeEach(() => {
+    original = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+    for (const key of ENV_KEYS) delete process.env[key];
+    tempDir = mkdtempSync(join(tmpdir(), 'gbrain-providers-'));
+    process.env.GBRAIN_HOME = tempDir;
+    logs = [];
+    originalLog = console.log;
+    console.log = (...args: unknown[]) => { logs.push(args.map(String).join(' ')); };
+  });
+
+  afterEach(() => {
+    console.log = originalLog;
+    for (const key of ENV_KEYS) {
+      const value = original[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('list --json reports readiness without secret values', async () => {
+    const authPath = join(tempDir, 'auth-profiles.json');
+    writeFileSync(authPath, JSON.stringify({
+      version: 1,
+      profiles: {
+        'openai:default': { type: 'api_key', provider: 'openai', key: 'profile-secret' },
+      },
+    }));
+    process.env.GBRAIN_OPENCLAW_AUTH_PROFILES_PATH = authPath;
+
+    await runProviders('list', ['--json']);
+    const output = logs.join('\n');
+    expect(output).toContain('"ready": true');
+    expect(output).toContain('openclaw:auth-profiles');
+    expect(output).not.toContain('profile-secret');
+  });
+
+  test('explain --json redacts env secret values', async () => {
+    process.env.OPENAI_API_KEY = 'env-secret';
+
+    await runProviders('explain', ['--json']);
+    const output = logs.join('\n');
+    expect(output).toContain('env:OPENAI_API_KEY');
+    expect(output).toContain('"ready": true');
+    expect(output).not.toContain('env-secret');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a minimal OpenAI auth resolver for GBrain embedding calls.
- Keeps precedence backward-compatible: `OPENAI_API_KEY` env > `gbrain` config `openai_api_key` > OpenClaw auth profile/host bridge.
- Adds `gbrain providers list|explain` so agents can inspect readiness without printing secrets.
- Updates `put_page` and hybrid vector search gates to use the resolver instead of hard-coded `process.env.OPENAI_API_KEY`.

## Release recommendation
Ship this small bridge instead of salvaging #17. PR #17 is broad, conflicts with master, adds a full provider gateway stack and dependency churn. This PR is the smallest releaseable path for today's extraction/embedding blocker.

Codex OAuth tokens are deliberately not treated as OpenAI embedding API keys. Direct Codex OAuth for embeddings should wait until OpenClaw exposes a supported credential bridge/token-exchange. Explicit OpenAI-compatible keys in OpenClaw auth profiles or env-secret refs are supported now.

## Tests
- `bun run typecheck`
- `bun test test/ai/auth.test.ts test/ai/providers.test.ts --timeout=60000`
- Manual redaction smoke: `OPENAI_API_KEY=test-secret bun run src/cli.ts providers list --json` did not print the secret.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `providers list|explain` CLI command to display OpenAI provider configuration and authentication status.
  * Enhanced credential detection supporting environment variables, configuration files, and multiple authentication sources for more flexible OpenAI setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->