### PR TITLE
feat: media evidence ingest + OpenClaw extraction bridge (rebased from #15)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -465,28 +465,8 @@ async function handleCliOnly(command: string, args: string[]) {
         break;
       }
       case 'ingest-media': {
-        const { ingestMediaEvidence } = await import('./commands/files.ts');
-        const filePath = args.find(a => !a.startsWith('--'));
-        const extractionPath = args.find((a, i) => args[i - 1] === '--extract');
-        const slug = args.find((a, i) => args[i - 1] === '--slug');
-        const title = args.find((a, i) => args[i - 1] === '--title');
-        const source = args.find((a, i) => args[i - 1] === '--source');
-        const type = args.find((a, i) => args[i - 1] === '--type');
-        const noFile = args.includes('--no-file');
-        if (!filePath || !extractionPath) {
-          console.error('Usage: gbrain ingest-media <file> --extract <json> [--slug <s>] [--title <t>] [--source <src>] [--type <type>] [--no-file]');
-          process.exit(1);
-        }
-        const result = await ingestMediaEvidence(engine, {
-          path: filePath,
-          extractionPath,
-          slug: slug || undefined,
-          title: title || undefined,
-          source: source || undefined,
-          type: type || undefined,
-          noFile,
-        });
-        console.log(JSON.stringify({ success: true, ...result }, null, 2));
+        const { runIngestMedia } = await import('./commands/import-media.ts');
+        await runIngestMedia(engine, args);
         break;
       }
       case 'embed': {
@@ -705,7 +685,7 @@ IMPORT/EXPORT
   import <dir> [--no-embed]          Import markdown directory
   import-media --slug <slug> --content-file <md> --extraction <json>
                                      Import normalized media evidence into a page
-  ingest-media <file> --extract <j>  Ingest media evidence into a media page
+  ingest-media <file> --extract <j>  Alias for normalized media evidence ingest
   sync [--repo <path>] [flags]       Git-to-brain incremental sync
   sync --watch [--interval N]        Continuous sync (loops until stopped)
   sync --install-cron                Install persistent sync daemon

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ for (const op of operations) {
 }
 
 // CLI-only commands that bypass the operation layer
-const CLI_ONLY = new Set(['init', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'storage', 'repos', 'code-def', 'code-refs', 'reindex-code', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'providers', 'ingest-media']);
+const CLI_ONLY = new Set(['init', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'import-media', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'storage', 'repos', 'code-def', 'code-refs', 'reindex-code', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'providers', 'ingest-media']);
 
 async function main() {
   // Parse global flags (--quiet / --progress-json / --progress-interval)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ for (const op of operations) {
 }
 
 // CLI-only commands that bypass the operation layer
-const CLI_ONLY = new Set(['init', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'storage', 'repos', 'code-def', 'code-refs', 'reindex-code', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'providers']);
+const CLI_ONLY = new Set(['init', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'storage', 'repos', 'code-def', 'code-refs', 'reindex-code', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'providers', 'ingest-media']);
 
 async function main() {
   // Parse global flags (--quiet / --progress-json / --progress-interval)
@@ -464,6 +464,31 @@ async function handleCliOnly(command: string, args: string[]) {
         await runFiles(engine, args);
         break;
       }
+      case 'ingest-media': {
+        const { ingestMediaEvidence } = await import('./commands/files.ts');
+        const filePath = args.find(a => !a.startsWith('--'));
+        const extractionPath = args.find((a, i) => args[i - 1] === '--extract');
+        const slug = args.find((a, i) => args[i - 1] === '--slug');
+        const title = args.find((a, i) => args[i - 1] === '--title');
+        const source = args.find((a, i) => args[i - 1] === '--source');
+        const type = args.find((a, i) => args[i - 1] === '--type');
+        const noFile = args.includes('--no-file');
+        if (!filePath || !extractionPath) {
+          console.error('Usage: gbrain ingest-media <file> --extract <json> [--slug <s>] [--title <t>] [--source <src>] [--type <type>] [--no-file]');
+          process.exit(1);
+        }
+        const result = await ingestMediaEvidence(engine, {
+          path: filePath,
+          extractionPath,
+          slug: slug || undefined,
+          title: title || undefined,
+          source: source || undefined,
+          type: type || undefined,
+          noFile,
+        });
+        console.log(JSON.stringify({ success: true, ...result }, null, 2));
+        break;
+      }
       case 'embed': {
         const { runEmbed } = await import('./commands/embed.ts');
         await runEmbed(engine, args);
@@ -680,6 +705,7 @@ IMPORT/EXPORT
   import <dir> [--no-embed]          Import markdown directory
   import-media --slug <slug> --content-file <md> --extraction <json>
                                      Import normalized media evidence into a page
+  ingest-media <file> --extract <j>  Ingest media evidence into a media page
   sync [--repo <path>] [flags]       Git-to-brain incremental sync
   sync --watch [--interval N]        Continuous sync (loops until stopped)
   sync --install-cron                Install persistent sync daemon

--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -44,17 +44,42 @@ function fileHash(filePath: string): string {
   return createHash('sha256').update(content).digest('hex');
 }
 
-export interface IngestMediaOptions {
-  path: string;
-  slug?: string;
-  title?: string;
-  type?: string;
-  source?: string;
-  extractionPath?: string;
-  extractionSource?: string;
-  summary?: string;
-  noFile?: boolean;
+export { getMimeType };
+
+export async function canAttachFiles(engine: BrainEngine): Promise<boolean> {
+  try {
+    await engine.executeRaw('SELECT 1 FROM files LIMIT 1');
+    return true;
+  } catch {
+    return false;
+  }
 }
+
+export async function attachFileRecordWithEngine(engine: BrainEngine, pageSlug: string, filePath: string, mimeType: string | null, sizeBytes: number): Promise<string> {
+  try {
+    return await attachFileRecord(pageSlug, filePath, mimeType, sizeBytes);
+  } catch {
+    const filename = basename(filePath);
+    const hash = fileHash(filePath);
+    const storagePath = `${pageSlug}/${filename}`;
+    const pageRows = await engine.executeRaw<{ id: number }>('SELECT id FROM pages WHERE slug = $1 LIMIT 1', [pageSlug]);
+    const pageId = pageRows[0]?.id ?? null;
+    await engine.executeRaw(
+      `INSERT INTO files (page_slug, page_id, filename, storage_path, mime_type, size_bytes, content_hash, metadata)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
+       ON CONFLICT (storage_path) DO UPDATE SET
+         page_slug = EXCLUDED.page_slug,
+         page_id = EXCLUDED.page_id,
+         content_hash = EXCLUDED.content_hash,
+         size_bytes = EXCLUDED.size_bytes,
+         mime_type = EXCLUDED.mime_type,
+         metadata = EXCLUDED.metadata`,
+      [pageSlug, pageId, filename, storagePath, mimeType, sizeBytes, hash, JSON.stringify({ ingest: 'media-evidence-mvp' })],
+    );
+    return storagePath;
+  }
+}
+
 
 export interface IngestMediaResult {
   slug: string;
@@ -104,9 +129,6 @@ export async function runFiles(engine: BrainEngine, args: string[]) {
     case 'status':
       await filesStatus(args.slice(1));
       break;
-    case 'ingest-media':
-      await ingestMediaCli(engine, args.slice(1));
-      break;
     default:
       console.error(`Usage: gbrain files <command> [args]`);
       console.error(`  list [slug]               List files for a page (or all)`);
@@ -121,245 +143,28 @@ export async function runFiles(engine: BrainEngine, args: string[]) {
       console.error(`  restore <dir>             Download from storage, recreate local files`);
       console.error(`  clean <dir> [--yes]       Delete redirect pointers (irreversible)`);
       console.error(`  status                    Show migration status of directories`);
-      console.error(`  ingest-media <file> --extract <json> [--slug <s>] [--title <t>] [--source <src>]`);
       process.exit(1);
   }
 }
 
-export async function ingestMediaEvidence(engine: BrainEngine, opts: IngestMediaOptions): Promise<IngestMediaResult> {
-  if (!opts.path || !existsSync(opts.path)) {
-    throw new Error(`Media file not found: ${opts.path}`);
-  }
-  if (!opts.extractionPath || !existsSync(opts.extractionPath)) {
-    throw new Error(`Extraction JSON not found: ${opts.extractionPath}`);
-  }
-
-  const extraction = JSON.parse(readFileSync(opts.extractionPath, 'utf-8')) as Record<string, unknown>;
-  const stat = statSync(opts.path);
-  const filename = basename(opts.path);
-  const mimeType = getMimeType(opts.path);
-  const mediaType = normalizeMediaType(opts.type, mimeType, filename);
-  const slug = opts.slug || defaultMediaSlug(filename);
-  const title = opts.title || filename;
-  const extractionSource = opts.extractionSource || opts.source || 'media-ingest';
-
-  const searchable = buildSearchableText(extraction, opts.summary);
-  if (!searchable.trim()) {
-    throw new Error('Extraction JSON did not contain searchable text.');
-  }
-
-  const frontmatter: Record<string, unknown> = {
-    media_type: mediaType,
-    source_path: opts.path,
-    filename,
-    mime_type: mimeType,
-    size_bytes: stat.size,
-    ingestion: 'media-evidence-mvp',
-  };
-
-  const page: PageInput = {
-    title,
-    type: 'media',
-    compiled_truth: searchable,
-    timeline: '',
-    frontmatter,
-  };
-
-  const existing = await engine.getPage(slug);
-  await engine.transaction(async (tx) => {
-    if (existing) await tx.createVersion(slug);
-    await tx.putPage(slug, page);
-    await tx.putRawData(slug, extractionSource, {
-      media: {
-        path: opts.path,
-        filename,
-        mime_type: mimeType,
-        size_bytes: stat.size,
-        media_type: mediaType,
-      },
-      extraction,
-    });
-    const chunks: ChunkInput[] = chunkText(searchable).map((c, idx) => ({
-      chunk_index: idx,
-      chunk_text: c.text,
-      chunk_source: 'compiled_truth',
-    }));
-    await tx.upsertChunks(slug, chunks);
-  });
-
-  let storagePath: string | null = null;
-  let fileAttached = false;
-  if (!opts.noFile) {
-    const fileSupport = await canAttachFiles(engine);
-    storagePath = `${slug}/${filename}`;
-    if (fileSupport) {
-      await attachFileRecordWithEngine(engine, slug, opts.path, mimeType, stat.size);
-      fileAttached = true;
-    }
-  }
-
-  await engine.logIngest({
-    source_type: 'media',
-    source_ref: opts.path,
-    pages_updated: [slug],
-    summary: opts.summary || `Ingested ${mediaType} evidence for ${slug}`,
-  });
-
-  return {
-    slug,
-    fileAttached,
-    storagePath,
-    rawDataSource: extractionSource,
-    chunksExpected: chunkEstimate(searchable),
-  };
-}
-
-async function ingestMediaCli(engine: BrainEngine, args: string[]) {
-  const filePath = args.find(a => !a.startsWith('--'));
-  const extractionPath = args.find((a, i) => args[i - 1] === '--extract');
-  const slug = args.find((a, i) => args[i - 1] === '--slug');
-  const title = args.find((a, i) => args[i - 1] === '--title');
-  const source = args.find((a, i) => args[i - 1] === '--source');
-  const type = args.find((a, i) => args[i - 1] === '--type');
-  const noFile = args.includes('--no-file');
-
-  if (!filePath || !extractionPath) {
-    console.error('Usage: gbrain files ingest-media <file> --extract <json> [--slug <s>] [--title <t>] [--source <src>] [--type <type>] [--no-file]');
-    process.exit(1);
-  }
-
-  const result = await ingestMediaEvidence(engine, {
-    path: filePath,
-    extractionPath,
-    slug: slug || undefined,
-    title: title || undefined,
-    source: source || undefined,
-    type: type || undefined,
-    noFile,
-  });
-
-  console.log(JSON.stringify({ success: true, ...result }, null, 2));
-}
-
-function normalizeMediaType(explicit: string | undefined, mimeType: string | null, filename: string): string {
-  if (explicit && explicit.trim()) return explicit.trim();
-  if (mimeType?.startsWith('image/')) return 'image';
-  if (mimeType === 'application/pdf') return 'pdf';
-  if (mimeType?.startsWith('video/')) return 'video';
-  if (mimeType?.startsWith('audio/')) return 'audio';
-  const ext = extname(filename).toLowerCase();
-  if (ext === '.pdf') return 'pdf';
-  return 'media';
-}
-
-function defaultMediaSlug(filename: string): string {
-  const stem = basename(filename, extname(filename))
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '') || 'untitled';
-  return `media/evidence/${stem}`;
-}
-
-function buildSearchableText(extraction: Record<string, unknown>, summary?: string): string {
-  const parts: string[] = [];
-  if (summary?.trim()) parts.push(summary.trim());
-  collectText(extraction, parts);
-  const seen = new Set<string>();
-  return parts
-    .map(part => part.trim())
-    .filter(Boolean)
-    .filter(part => {
-      if (seen.has(part)) return false;
-      seen.add(part);
-      return true;
-    })
-    .join('\n\n');
-}
-
-function collectText(value: unknown, parts: string[]): void {
-  if (typeof value === 'string') {
-    const trimmed = value.trim();
-    if (trimmed) parts.push(trimmed);
-    return;
-  }
-  if (Array.isArray(value)) {
-    for (const item of value) collectText(item, parts);
-    return;
-  }
-  if (value && typeof value === 'object') {
-    for (const [key, child] of Object.entries(value)) {
-      if (typeof child === 'string' && /(text|caption|ocr|transcript|summary|description|content)/i.test(key)) {
-        collectText(child, parts);
-      } else if (Array.isArray(child) || (child && typeof child === 'object')) {
-        collectText(child, parts);
-      }
-    }
-  }
-}
-
-async function attachFileRecordWithEngine(engine: BrainEngine, pageSlug: string, filePath: string, mimeType: string | null, sizeBytes: number): Promise<string> {
-  try {
-    return await attachFileRecord(pageSlug, filePath, mimeType, sizeBytes);
-  } catch {
-    const filename = basename(filePath);
-    const hash = fileHash(filePath);
-    const storagePath = `${pageSlug}/${filename}`;
-    const pageRows = await engine.executeRaw<{ id: number }>('SELECT id FROM pages WHERE slug = $1 LIMIT 1', [pageSlug]);
-    const pageId = pageRows[0]?.id ?? null;
-    await engine.executeRaw(
-      `INSERT INTO files (page_slug, page_id, filename, storage_path, mime_type, size_bytes, content_hash, metadata)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
-       ON CONFLICT (storage_path) DO UPDATE SET
-         page_slug = EXCLUDED.page_slug,
-         page_id = EXCLUDED.page_id,
-         content_hash = EXCLUDED.content_hash,
-         size_bytes = EXCLUDED.size_bytes,
-         mime_type = EXCLUDED.mime_type,
-         metadata = EXCLUDED.metadata`,
-      [pageSlug, pageId, filename, storagePath, mimeType, sizeBytes, hash, JSON.stringify({ ingest: 'media-evidence-mvp' })],
-    );
-    return storagePath;
-  }
-}
-
 async function attachFileRecord(pageSlug: string, filePath: string, mimeType: string | null, sizeBytes: number): Promise<string> {
+  const sql = db.getConnection();
   const filename = basename(filePath);
   const hash = fileHash(filePath);
   const storagePath = `${pageSlug}/${filename}`;
 
-  // Prefer the shared postgres/sql path when available, but fall back to the
-  // engine's raw SQL support so PGLite tests and local brains work too.
-  try {
-    const sql = db.getConnection();
-    await sql`
-      INSERT INTO files (page_slug, filename, storage_path, mime_type, size_bytes, content_hash, metadata)
-      VALUES (${pageSlug}, ${filename}, ${storagePath}, ${mimeType}, ${sizeBytes}, ${hash}, ${sql.json({ ingest: 'media-evidence-mvp' })})
-      ON CONFLICT (storage_path) DO UPDATE SET
-        page_slug = EXCLUDED.page_slug,
-        content_hash = EXCLUDED.content_hash,
-        size_bytes = EXCLUDED.size_bytes,
-        mime_type = EXCLUDED.mime_type,
-        metadata = EXCLUDED.metadata
-    `;
-    return storagePath;
-  } catch {
-    // caller will use engine fallback below
-  }
+  await sql`
+    INSERT INTO files (page_slug, filename, storage_path, mime_type, size_bytes, content_hash, metadata)
+    VALUES (${pageSlug}, ${filename}, ${storagePath}, ${mimeType}, ${sizeBytes}, ${hash}, ${sql.json({ ingest: 'media-evidence-mvp' })})
+    ON CONFLICT (storage_path) DO UPDATE SET
+      page_slug = EXCLUDED.page_slug,
+      content_hash = EXCLUDED.content_hash,
+      size_bytes = EXCLUDED.size_bytes,
+      mime_type = EXCLUDED.mime_type,
+      metadata = EXCLUDED.metadata
+  `;
 
-  throw new Error('attachFileRecord requires SQL connection fallback wiring');
-}
-
-async function canAttachFiles(engine: BrainEngine): Promise<boolean> {
-  try {
-    await engine.executeRaw('SELECT 1 FROM files LIMIT 1');
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function chunkEstimate(text: string): number {
-  return Math.max(1, Math.ceil(text.length / 1200));
+  return storagePath;
 }
 
 async function listFiles(slug?: string) {

--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -6,6 +6,8 @@ import * as db from '../core/db.ts';
 import { humanSize } from '../core/file-resolver.ts';
 import { createProgress } from '../core/progress.ts';
 import { getCliOptions, cliOptsToProgressOptions } from '../core/cli-options.ts';
+import { chunkText } from '../core/chunkers/recursive.ts';
+import type { ChunkInput, PageInput } from '../core/types.ts';
 
 /** Size threshold: files >= 100 MB use TUS resumable upload */
 const SIZE_THRESHOLD = 100 * 1024 * 1024;
@@ -40,6 +42,26 @@ function getMimeType(filePath: string): string | null {
 function fileHash(filePath: string): string {
   const content = readFileSync(filePath);
   return createHash('sha256').update(content).digest('hex');
+}
+
+export interface IngestMediaOptions {
+  path: string;
+  slug?: string;
+  title?: string;
+  type?: string;
+  source?: string;
+  extractionPath?: string;
+  extractionSource?: string;
+  summary?: string;
+  noFile?: boolean;
+}
+
+export interface IngestMediaResult {
+  slug: string;
+  fileAttached: boolean;
+  storagePath: string | null;
+  rawDataSource: string;
+  chunksExpected: number;
 }
 
 export async function runFiles(engine: BrainEngine, args: string[]) {
@@ -82,6 +104,9 @@ export async function runFiles(engine: BrainEngine, args: string[]) {
     case 'status':
       await filesStatus(args.slice(1));
       break;
+    case 'ingest-media':
+      await ingestMediaCli(engine, args.slice(1));
+      break;
     default:
       console.error(`Usage: gbrain files <command> [args]`);
       console.error(`  list [slug]               List files for a page (or all)`);
@@ -96,8 +121,245 @@ export async function runFiles(engine: BrainEngine, args: string[]) {
       console.error(`  restore <dir>             Download from storage, recreate local files`);
       console.error(`  clean <dir> [--yes]       Delete redirect pointers (irreversible)`);
       console.error(`  status                    Show migration status of directories`);
+      console.error(`  ingest-media <file> --extract <json> [--slug <s>] [--title <t>] [--source <src>]`);
       process.exit(1);
   }
+}
+
+export async function ingestMediaEvidence(engine: BrainEngine, opts: IngestMediaOptions): Promise<IngestMediaResult> {
+  if (!opts.path || !existsSync(opts.path)) {
+    throw new Error(`Media file not found: ${opts.path}`);
+  }
+  if (!opts.extractionPath || !existsSync(opts.extractionPath)) {
+    throw new Error(`Extraction JSON not found: ${opts.extractionPath}`);
+  }
+
+  const extraction = JSON.parse(readFileSync(opts.extractionPath, 'utf-8')) as Record<string, unknown>;
+  const stat = statSync(opts.path);
+  const filename = basename(opts.path);
+  const mimeType = getMimeType(opts.path);
+  const mediaType = normalizeMediaType(opts.type, mimeType, filename);
+  const slug = opts.slug || defaultMediaSlug(filename);
+  const title = opts.title || filename;
+  const extractionSource = opts.extractionSource || opts.source || 'media-ingest';
+
+  const searchable = buildSearchableText(extraction, opts.summary);
+  if (!searchable.trim()) {
+    throw new Error('Extraction JSON did not contain searchable text.');
+  }
+
+  const frontmatter: Record<string, unknown> = {
+    media_type: mediaType,
+    source_path: opts.path,
+    filename,
+    mime_type: mimeType,
+    size_bytes: stat.size,
+    ingestion: 'media-evidence-mvp',
+  };
+
+  const page: PageInput = {
+    title,
+    type: 'media',
+    compiled_truth: searchable,
+    timeline: '',
+    frontmatter,
+  };
+
+  const existing = await engine.getPage(slug);
+  await engine.transaction(async (tx) => {
+    if (existing) await tx.createVersion(slug);
+    await tx.putPage(slug, page);
+    await tx.putRawData(slug, extractionSource, {
+      media: {
+        path: opts.path,
+        filename,
+        mime_type: mimeType,
+        size_bytes: stat.size,
+        media_type: mediaType,
+      },
+      extraction,
+    });
+    const chunks: ChunkInput[] = chunkText(searchable).map((c, idx) => ({
+      chunk_index: idx,
+      chunk_text: c.text,
+      chunk_source: 'compiled_truth',
+    }));
+    await tx.upsertChunks(slug, chunks);
+  });
+
+  let storagePath: string | null = null;
+  let fileAttached = false;
+  if (!opts.noFile) {
+    const fileSupport = await canAttachFiles(engine);
+    storagePath = `${slug}/${filename}`;
+    if (fileSupport) {
+      await attachFileRecordWithEngine(engine, slug, opts.path, mimeType, stat.size);
+      fileAttached = true;
+    }
+  }
+
+  await engine.logIngest({
+    source_type: 'media',
+    source_ref: opts.path,
+    pages_updated: [slug],
+    summary: opts.summary || `Ingested ${mediaType} evidence for ${slug}`,
+  });
+
+  return {
+    slug,
+    fileAttached,
+    storagePath,
+    rawDataSource: extractionSource,
+    chunksExpected: chunkEstimate(searchable),
+  };
+}
+
+async function ingestMediaCli(engine: BrainEngine, args: string[]) {
+  const filePath = args.find(a => !a.startsWith('--'));
+  const extractionPath = args.find((a, i) => args[i - 1] === '--extract');
+  const slug = args.find((a, i) => args[i - 1] === '--slug');
+  const title = args.find((a, i) => args[i - 1] === '--title');
+  const source = args.find((a, i) => args[i - 1] === '--source');
+  const type = args.find((a, i) => args[i - 1] === '--type');
+  const noFile = args.includes('--no-file');
+
+  if (!filePath || !extractionPath) {
+    console.error('Usage: gbrain files ingest-media <file> --extract <json> [--slug <s>] [--title <t>] [--source <src>] [--type <type>] [--no-file]');
+    process.exit(1);
+  }
+
+  const result = await ingestMediaEvidence(engine, {
+    path: filePath,
+    extractionPath,
+    slug: slug || undefined,
+    title: title || undefined,
+    source: source || undefined,
+    type: type || undefined,
+    noFile,
+  });
+
+  console.log(JSON.stringify({ success: true, ...result }, null, 2));
+}
+
+function normalizeMediaType(explicit: string | undefined, mimeType: string | null, filename: string): string {
+  if (explicit && explicit.trim()) return explicit.trim();
+  if (mimeType?.startsWith('image/')) return 'image';
+  if (mimeType === 'application/pdf') return 'pdf';
+  if (mimeType?.startsWith('video/')) return 'video';
+  if (mimeType?.startsWith('audio/')) return 'audio';
+  const ext = extname(filename).toLowerCase();
+  if (ext === '.pdf') return 'pdf';
+  return 'media';
+}
+
+function defaultMediaSlug(filename: string): string {
+  const stem = basename(filename, extname(filename))
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'untitled';
+  return `media/evidence/${stem}`;
+}
+
+function buildSearchableText(extraction: Record<string, unknown>, summary?: string): string {
+  const parts: string[] = [];
+  if (summary?.trim()) parts.push(summary.trim());
+  collectText(extraction, parts);
+  const seen = new Set<string>();
+  return parts
+    .map(part => part.trim())
+    .filter(Boolean)
+    .filter(part => {
+      if (seen.has(part)) return false;
+      seen.add(part);
+      return true;
+    })
+    .join('\n\n');
+}
+
+function collectText(value: unknown, parts: string[]): void {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed) parts.push(trimmed);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectText(item, parts);
+    return;
+  }
+  if (value && typeof value === 'object') {
+    for (const [key, child] of Object.entries(value)) {
+      if (typeof child === 'string' && /(text|caption|ocr|transcript|summary|description|content)/i.test(key)) {
+        collectText(child, parts);
+      } else if (Array.isArray(child) || (child && typeof child === 'object')) {
+        collectText(child, parts);
+      }
+    }
+  }
+}
+
+async function attachFileRecordWithEngine(engine: BrainEngine, pageSlug: string, filePath: string, mimeType: string | null, sizeBytes: number): Promise<string> {
+  try {
+    return await attachFileRecord(pageSlug, filePath, mimeType, sizeBytes);
+  } catch {
+    const filename = basename(filePath);
+    const hash = fileHash(filePath);
+    const storagePath = `${pageSlug}/${filename}`;
+    const pageRows = await engine.executeRaw<{ id: number }>('SELECT id FROM pages WHERE slug = $1 LIMIT 1', [pageSlug]);
+    const pageId = pageRows[0]?.id ?? null;
+    await engine.executeRaw(
+      `INSERT INTO files (page_slug, page_id, filename, storage_path, mime_type, size_bytes, content_hash, metadata)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
+       ON CONFLICT (storage_path) DO UPDATE SET
+         page_slug = EXCLUDED.page_slug,
+         page_id = EXCLUDED.page_id,
+         content_hash = EXCLUDED.content_hash,
+         size_bytes = EXCLUDED.size_bytes,
+         mime_type = EXCLUDED.mime_type,
+         metadata = EXCLUDED.metadata`,
+      [pageSlug, pageId, filename, storagePath, mimeType, sizeBytes, hash, JSON.stringify({ ingest: 'media-evidence-mvp' })],
+    );
+    return storagePath;
+  }
+}
+
+async function attachFileRecord(pageSlug: string, filePath: string, mimeType: string | null, sizeBytes: number): Promise<string> {
+  const filename = basename(filePath);
+  const hash = fileHash(filePath);
+  const storagePath = `${pageSlug}/${filename}`;
+
+  // Prefer the shared postgres/sql path when available, but fall back to the
+  // engine's raw SQL support so PGLite tests and local brains work too.
+  try {
+    const sql = db.getConnection();
+    await sql`
+      INSERT INTO files (page_slug, filename, storage_path, mime_type, size_bytes, content_hash, metadata)
+      VALUES (${pageSlug}, ${filename}, ${storagePath}, ${mimeType}, ${sizeBytes}, ${hash}, ${sql.json({ ingest: 'media-evidence-mvp' })})
+      ON CONFLICT (storage_path) DO UPDATE SET
+        page_slug = EXCLUDED.page_slug,
+        content_hash = EXCLUDED.content_hash,
+        size_bytes = EXCLUDED.size_bytes,
+        mime_type = EXCLUDED.mime_type,
+        metadata = EXCLUDED.metadata
+    `;
+    return storagePath;
+  } catch {
+    // caller will use engine fallback below
+  }
+
+  throw new Error('attachFileRecord requires SQL connection fallback wiring');
+}
+
+async function canAttachFiles(engine: BrainEngine): Promise<boolean> {
+  try {
+    await engine.executeRaw('SELECT 1 FROM files LIMIT 1');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function chunkEstimate(text: string): number {
+  return Math.max(1, Math.ceil(text.length / 1200));
 }
 
 async function listFiles(slug?: string) {

--- a/src/commands/import-media.ts
+++ b/src/commands/import-media.ts
@@ -1,10 +1,13 @@
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, statSync } from 'fs';
+import { basename, extname } from 'path';
 import type { BrainEngine } from '../core/engine.ts';
-import { importMediaEvidence } from '../core/import-file.ts';
-import { normalizeMediaExtraction, mediaExtractionToEvidence } from '../core/media-extraction.ts';
+import type { ChunkInput, PageInput } from '../core/types.ts';
+import { normalizeMediaExtraction, mediaExtractionToEvidence, type MediaEvidence, type MediaExtraction, type MediaExtractionKind } from '../core/media-extraction.ts';
+import { chunkText } from '../core/chunkers/recursive.ts';
+import { getMimeType, canAttachFiles, attachFileRecordWithEngine, type IngestMediaResult } from './files.ts';
 
 function usage(): never {
-  console.error('Usage: gbrain import-media --slug <slug> --content-file <file.md> --extraction <file.json> [--source <name>] [--raw-data-source <name>] [--no-embed]');
+  console.error('Usage: gbrain import-media --slug <slug> --content-file <file.md> --extraction <file.json> [--source <name>] [--raw-data-source <name>] [--media-file <path>] [--title <title>] [--type <kind>] [--no-file] [--no-embed]');
   process.exit(1);
 }
 
@@ -13,34 +16,178 @@ function getFlag(args: string[], name: string): string | undefined {
   return idx !== -1 ? args[idx + 1] : undefined;
 }
 
+function defaultMediaSlug(filename: string): string {
+  const stem = basename(filename, extname(filename))
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'untitled';
+  return `media/evidence/${stem}`;
+}
+
+function defaultContent(title: string, evidence: MediaEvidence): string {
+  const fmType = evidence.kind === 'pdf' ? 'media' : 'media';
+  return `---\ntype: ${fmType}\ntitle: ${title}\n---\n\n${evidence.text}\n`;
+}
+
+function chunkEvidence(evidence: MediaEvidence): ChunkInput[] {
+  return chunkText(evidence.text).map((c, idx) => ({
+    chunk_index: idx,
+    chunk_text: c.text,
+    chunk_source: 'compiled_truth',
+  }));
+}
+
+function fileKindOverride(explicit: string | undefined, extraction: MediaExtraction, mimeType: string | null): MediaExtractionKind {
+  if (explicit && ['image', 'pdf', 'video', 'audio'].includes(explicit)) return explicit as MediaExtractionKind;
+  if (mimeType === 'application/pdf') return 'pdf';
+  return extraction.kind;
+}
+
+export async function importNormalizedMediaEvidence(
+  engine: BrainEngine,
+  opts: {
+    slug: string;
+    content: string;
+    evidence: MediaEvidence;
+    rawDataSource?: string;
+    mediaFilePath?: string;
+    pageTitle?: string;
+    noFile?: boolean;
+  },
+): Promise<IngestMediaResult> {
+  const pageTitle = opts.pageTitle || opts.evidence.sourceRef || opts.slug;
+  const compiledTruth = opts.evidence.text;
+  if (!compiledTruth.trim()) throw new Error('Normalized evidence text is empty.');
+
+  const filePath = opts.mediaFilePath;
+  const mimeType = filePath ? getMimeType(filePath) : null;
+  const stat = filePath && existsSync(filePath) ? statSync(filePath) : null;
+  const filename = filePath ? basename(filePath) : undefined;
+
+  const frontmatter: Record<string, unknown> = {
+    media_type: opts.evidence.kind,
+    source_ref: opts.evidence.sourceRef,
+    evidence_schema: opts.evidence.schemaVersion,
+    ...(filename ? { filename } : {}),
+    ...(mimeType ? { mime_type: mimeType } : {}),
+    ...(stat ? { size_bytes: stat.size } : {}),
+    ingestion: 'media-evidence-mvp',
+  };
+
+  const page: PageInput = {
+    title: pageTitle,
+    type: 'media',
+    compiled_truth: compiledTruth,
+    timeline: '',
+    frontmatter,
+  };
+
+  const existing = await engine.getPage(opts.slug);
+  await engine.transaction(async (tx) => {
+    if (existing) await tx.createVersion(opts.slug);
+    await tx.putPage(opts.slug, page);
+    await tx.putRawData(opts.slug, opts.rawDataSource ?? 'media-extraction', opts.evidence as unknown as object);
+    await tx.upsertChunks(opts.slug, chunkEvidence(opts.evidence));
+  });
+
+  let storagePath: string | null = null;
+  let fileAttached = false;
+  if (filePath && !opts.noFile) {
+    storagePath = `${opts.slug}/${basename(filePath)}`;
+    if (await canAttachFiles(engine)) {
+      await attachFileRecordWithEngine(engine, opts.slug, filePath, mimeType, stat?.size ?? 0);
+      fileAttached = true;
+    }
+  }
+
+  await engine.logIngest({
+    source_type: 'media',
+    source_ref: filePath || opts.slug,
+    pages_updated: [opts.slug],
+    summary: `Imported normalized ${opts.evidence.kind} evidence for ${opts.slug}`,
+  });
+
+  return {
+    slug: opts.slug,
+    fileAttached,
+    storagePath,
+    rawDataSource: opts.rawDataSource ?? 'media-extraction',
+    chunksExpected: chunkEvidence(opts.evidence).length,
+  };
+}
+
 export async function runImportMedia(engine: BrainEngine, args: string[]) {
   const slug = getFlag(args, '--slug');
   const contentFile = getFlag(args, '--content-file');
   const extractionFile = getFlag(args, '--extraction');
   const source = getFlag(args, '--source');
   const rawDataSource = getFlag(args, '--raw-data-source');
+  const mediaFilePath = getFlag(args, '--media-file');
+  const title = getFlag(args, '--title');
+  const type = getFlag(args, '--type');
   const noEmbed = args.includes('--no-embed');
+  const noFile = args.includes('--no-file');
 
-  if (!slug || !contentFile || !extractionFile) usage();
-  if (!existsSync(contentFile) || !existsSync(extractionFile)) usage();
+  if (!slug || !extractionFile) usage();
+  if ((contentFile && !existsSync(contentFile)) || !existsSync(extractionFile) || (mediaFilePath && !existsSync(mediaFilePath))) usage();
 
-  const content = readFileSync(contentFile, 'utf-8');
   const extractionJson = JSON.parse(readFileSync(extractionFile, 'utf-8')) as unknown;
-  const extraction = normalizeMediaExtraction(extractionJson);
-  const evidence = mediaExtractionToEvidence(extraction);
+  const normalized = normalizeMediaExtraction(extractionJson);
+  const evidence = mediaExtractionToEvidence({
+    ...normalized,
+    kind: fileKindOverride(type, normalized, mediaFilePath ? getMimeType(mediaFilePath) : null),
+    sourceRef: source || mediaFilePath || normalized.sourceRef || normalized.title,
+  });
 
-  const result = await importMediaEvidence(engine, slug, content, extraction, {
-    noEmbed,
-    source,
-    rawDataSource,
+  const finalTitle = title || normalized.title || (mediaFilePath ? basename(mediaFilePath) : slug);
+  const content = contentFile ? readFileSync(contentFile, 'utf-8') : defaultContent(finalTitle, evidence);
+
+  const result = await importNormalizedMediaEvidence(engine, {
+    slug,
+    content,
+    evidence,
+    rawDataSource: rawDataSource ?? 'gbrain.media-evidence.v1',
+    mediaFilePath,
+    pageTitle: finalTitle,
+    noFile,
   });
 
   console.log(JSON.stringify({
-    status: result.status,
+    status: 'imported',
     slug: result.slug,
-    chunks: result.chunks,
-    raw_data_source: rawDataSource ?? source ?? 'media-extraction',
+    raw_data_source: result.rawDataSource,
     segment_count: evidence.segments.length,
     evidence_text_length: evidence.text.length,
+    file_attached: result.fileAttached,
+    storage_path: result.storagePath,
+    no_embed: noEmbed,
   }, null, 2));
+}
+
+export async function runIngestMedia(engine: BrainEngine, args: string[]) {
+  const mediaFile = args.find(a => !a.startsWith('--'));
+  const extractionFile = getFlag(args, '--extract');
+  const slug = getFlag(args, '--slug');
+  const title = getFlag(args, '--title');
+  const source = getFlag(args, '--source');
+  const type = getFlag(args, '--type');
+  const noFile = args.includes('--no-file');
+  const noEmbed = args.includes('--no-embed');
+
+  if (!mediaFile || !extractionFile) {
+    console.error('Usage: gbrain ingest-media <file> --extract <json> [--slug <s>] [--title <t>] [--source <src>] [--type <kind>] [--no-file] [--no-embed]');
+    process.exit(1);
+  }
+
+  await runImportMedia(engine, [
+    '--slug', slug || defaultMediaSlug(mediaFile),
+    '--extraction', extractionFile,
+    '--media-file', mediaFile,
+    '--raw-data-source', 'gbrain.media-evidence.v1',
+    ...(title ? ['--title', title] : []),
+    ...(source ? ['--source', source] : []),
+    ...(type ? ['--type', type] : []),
+    ...(noFile ? ['--no-file'] : []),
+    ...(noEmbed ? ['--no-embed'] : []),
+  ]);
 }

--- a/src/commands/import-media.ts
+++ b/src/commands/import-media.ts
@@ -45,7 +45,7 @@ function chunkMediaPage(page: PageInput, evidence: MediaEvidence): ChunkInput[] 
 
 function mediaEvidenceHash(page: PageInput, evidence: MediaEvidence): string {
   return createHash('sha256')
-    .update(JSON.stringify({
+    .update(stableStringify({
       title: page.title,
       type: page.type,
       compiled_truth: page.compiled_truth,
@@ -95,10 +95,7 @@ function rawDataEqualsExisting(rows: Array<{ data: unknown }>, evidence: MediaEv
 
 function pageMatchesExisting(existing: Awaited<ReturnType<BrainEngine['getPage']>>, page: PageInput): boolean {
   if (!existing) return false;
-  return existing.title === page.title
-    && existing.type === page.type
-    && existing.compiled_truth === page.compiled_truth
-    && (existing.timeline || '') === (page.timeline || '');
+  return existing.content_hash === page.content_hash;
 }
 
 function fileKindOverride(explicit: string | undefined, extraction: MediaExtraction, mimeType: string | null): MediaExtractionKind {
@@ -249,14 +246,16 @@ export async function runIngestMedia(engine: BrainEngine, args: string[]) {
   const noFile = args.includes('--no-file');
   const noEmbed = args.includes('--no-embed');
 
+  const contentFile = getFlag(args, '--content-file');
   if (!mediaFile || !extractionFile) {
-    console.error('Usage: gbrain ingest-media <file> --extract <json> [--slug <s>] [--title <t>] [--source <src>] [--type <kind>] [--no-file] [--no-embed]');
+    console.error('Usage: gbrain ingest-media <file> --extract <json> [--slug <s>] [--title <t>] [--source <src>] [--type <kind>] [--content-file <file.md>] [--no-file] [--no-embed]');
     process.exit(1);
   }
 
   await runImportMedia(engine, [
     '--slug', slug || defaultMediaSlug(mediaFile),
     '--extraction', extractionFile,
+    ...(contentFile ? ['--content-file', contentFile] : []),
     '--media-file', mediaFile,
     '--raw-data-source', 'gbrain.media-evidence.v1',
     ...(title ? ['--title', title] : []),

--- a/src/commands/import-media.ts
+++ b/src/commands/import-media.ts
@@ -31,8 +31,12 @@ function defaultContent(title: string, evidence: MediaEvidence): string {
   return `---\ntype: ${fmType}\ntitle: ${title}\n---\n\n${evidence.text}\n`;
 }
 
-function chunkEvidence(evidence: MediaEvidence): ChunkInput[] {
-  return chunkText(evidence.text).map((c, idx) => ({
+function chunkMediaPage(page: PageInput, evidence: MediaEvidence): ChunkInput[] {
+  const parts = [page.compiled_truth, evidence.text]
+    .map(part => part.trim())
+    .filter(Boolean);
+  const searchableText = Array.from(new Set(parts)).join('\n\n');
+  return chunkText(searchableText).map((c, idx) => ({
     chunk_index: idx,
     chunk_text: c.text,
     chunk_source: 'compiled_truth',
@@ -148,7 +152,7 @@ export async function importNormalizedMediaEvidence(
       if (existing && !unchanged) await tx.createVersion(opts.slug);
       await tx.putPage(opts.slug, page);
       await tx.putRawData(opts.slug, rawDataSource, opts.evidence as unknown as object);
-      const chunks = chunkEvidence(opts.evidence);
+      const chunks = chunkMediaPage(page, opts.evidence);
       if (chunks.length > 0) await tx.upsertChunks(opts.slug, chunks);
       else await tx.deleteChunks(opts.slug);
     });
@@ -178,7 +182,7 @@ export async function importNormalizedMediaEvidence(
     fileAttached,
     storagePath,
     rawDataSource,
-    chunksExpected: chunkEvidence(opts.evidence).length,
+    chunksExpected: chunkMediaPage(page, opts.evidence).length,
   };
 }
 
@@ -206,7 +210,12 @@ export async function runImportMedia(engine: BrainEngine, args: string[]) {
   });
 
   const finalTitle = title || normalized.title || (mediaFilePath ? basename(mediaFilePath) : slug);
-  const content = contentFile ? readFileSync(contentFile, 'utf-8') : defaultContent(finalTitle, evidence);
+  const existing = await engine.getPage(slug);
+  const content = contentFile
+    ? readFileSync(contentFile, 'utf-8')
+    : existing
+      ? `---\ntype: ${existing.type}\ntitle: ${existing.title}\n---\n\n${existing.compiled_truth}\n`
+      : defaultContent(finalTitle, evidence);
 
   const result = await importNormalizedMediaEvidence(engine, {
     slug,

--- a/src/commands/import-media.ts
+++ b/src/commands/import-media.ts
@@ -1,9 +1,11 @@
+import { createHash } from 'crypto';
 import { existsSync, readFileSync, statSync } from 'fs';
 import { basename, extname } from 'path';
 import type { BrainEngine } from '../core/engine.ts';
 import type { ChunkInput, PageInput } from '../core/types.ts';
 import { normalizeMediaExtraction, mediaExtractionToEvidence, type MediaEvidence, type MediaExtraction, type MediaExtractionKind } from '../core/media-extraction.ts';
 import { chunkText } from '../core/chunkers/recursive.ts';
+import { parseMarkdown } from '../core/markdown.ts';
 import { getMimeType, canAttachFiles, attachFileRecordWithEngine, type IngestMediaResult } from './files.ts';
 
 function usage(): never {
@@ -37,6 +39,64 @@ function chunkEvidence(evidence: MediaEvidence): ChunkInput[] {
   }));
 }
 
+function mediaEvidenceHash(page: PageInput, evidence: MediaEvidence): string {
+  return createHash('sha256')
+    .update(JSON.stringify({
+      title: page.title,
+      type: page.type,
+      compiled_truth: page.compiled_truth,
+      timeline: page.timeline || '',
+      frontmatter: page.frontmatter || {},
+      evidence,
+    }))
+    .digest('hex');
+}
+
+function parseMediaPageContent(content: string, slug: string, fallbackTitle: string, evidence: MediaEvidence): PageInput {
+  const parsed = parseMarkdown(content, `${slug}.md`);
+  return {
+    title: parsed.title || fallbackTitle,
+    type: 'media',
+    compiled_truth: parsed.compiled_truth || evidence.text,
+    timeline: parsed.timeline || '',
+    frontmatter: {
+      ...parsed.frontmatter,
+      media_type: evidence.kind,
+      source_ref: evidence.sourceRef,
+      evidence_schema: evidence.schemaVersion,
+      ingestion: 'media-evidence-mvp',
+    },
+  };
+}
+
+function stableStringify(value: unknown): string {
+  if (value === undefined) return '';
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, v]) => v !== undefined)
+      .sort(([a], [b]) => a.localeCompare(b));
+    return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function rawDataEqualsExisting(rows: Array<{ data: unknown }>, evidence: MediaEvidence): boolean {
+  if (rows.length !== 1) return false;
+  const existing = typeof rows[0]?.data === 'string'
+    ? JSON.parse(rows[0].data as string)
+    : rows[0]?.data;
+  return stableStringify(existing) === stableStringify(evidence);
+}
+
+function pageMatchesExisting(existing: Awaited<ReturnType<BrainEngine['getPage']>>, page: PageInput): boolean {
+  if (!existing) return false;
+  return existing.title === page.title
+    && existing.type === page.type
+    && existing.compiled_truth === page.compiled_truth
+    && (existing.timeline || '') === (page.timeline || '');
+}
+
 function fileKindOverride(explicit: string | undefined, extraction: MediaExtraction, mimeType: string | null): MediaExtractionKind {
   if (explicit && ['image', 'pdf', 'video', 'audio'].includes(explicit)) return explicit as MediaExtractionKind;
   if (mimeType === 'application/pdf') return 'pdf';
@@ -64,54 +124,60 @@ export async function importNormalizedMediaEvidence(
   const stat = filePath && existsSync(filePath) ? statSync(filePath) : null;
   const filename = filePath ? basename(filePath) : undefined;
 
-  const frontmatter: Record<string, unknown> = {
-    media_type: opts.evidence.kind,
-    source_ref: opts.evidence.sourceRef,
-    evidence_schema: opts.evidence.schemaVersion,
+  const fileFrontmatter: Record<string, unknown> = {
     ...(filename ? { filename } : {}),
     ...(mimeType ? { mime_type: mimeType } : {}),
     ...(stat ? { size_bytes: stat.size } : {}),
-    ingestion: 'media-evidence-mvp',
   };
 
-  const page: PageInput = {
-    title: pageTitle,
-    type: 'media',
-    compiled_truth: compiledTruth,
-    timeline: '',
-    frontmatter,
+  const rawDataSource = opts.rawDataSource ?? 'media-extraction';
+  const page: PageInput = parseMediaPageContent(opts.content, opts.slug, pageTitle, opts.evidence);
+  page.frontmatter = {
+    ...(page.frontmatter || {}),
+    ...fileFrontmatter,
   };
+  const contentHash = mediaEvidenceHash(page, opts.evidence);
+  page.content_hash = contentHash;
 
   const existing = await engine.getPage(opts.slug);
-  await engine.transaction(async (tx) => {
-    if (existing) await tx.createVersion(opts.slug);
-    await tx.putPage(opts.slug, page);
-    await tx.putRawData(opts.slug, opts.rawDataSource ?? 'media-extraction', opts.evidence as unknown as object);
-    await tx.upsertChunks(opts.slug, chunkEvidence(opts.evidence));
-  });
+  const existingRawData = existing ? await engine.getRawData(opts.slug, rawDataSource) : [];
+  const filesTableAvailable = filePath && !opts.noFile ? await canAttachFiles(engine) : false;
+  const unchanged = pageMatchesExisting(existing, page) && rawDataEqualsExisting(existingRawData, opts.evidence);
+  if (!unchanged) {
+    await engine.transaction(async (tx) => {
+      if (existing && !unchanged) await tx.createVersion(opts.slug);
+      await tx.putPage(opts.slug, page);
+      await tx.putRawData(opts.slug, rawDataSource, opts.evidence as unknown as object);
+      const chunks = chunkEvidence(opts.evidence);
+      if (chunks.length > 0) await tx.upsertChunks(opts.slug, chunks);
+      else await tx.deleteChunks(opts.slug);
+    });
+  }
 
   let storagePath: string | null = null;
   let fileAttached = false;
   if (filePath && !opts.noFile) {
     storagePath = `${opts.slug}/${basename(filePath)}`;
-    if (await canAttachFiles(engine)) {
+    if (filesTableAvailable) {
       await attachFileRecordWithEngine(engine, opts.slug, filePath, mimeType, stat?.size ?? 0);
       fileAttached = true;
     }
   }
 
-  await engine.logIngest({
-    source_type: 'media',
-    source_ref: filePath || opts.slug,
-    pages_updated: [opts.slug],
-    summary: `Imported normalized ${opts.evidence.kind} evidence for ${opts.slug}`,
-  });
+  if (!unchanged) {
+    await engine.logIngest({
+      source_type: 'media',
+      source_ref: filePath || opts.slug,
+      pages_updated: [opts.slug],
+      summary: `Imported normalized ${opts.evidence.kind} evidence for ${opts.slug}`,
+    });
+  }
 
   return {
     slug: opts.slug,
     fileAttached,
     storagePath,
-    rawDataSource: opts.rawDataSource ?? 'media-extraction',
+    rawDataSource,
     chunksExpected: chunkEvidence(opts.evidence).length,
   };
 }

--- a/src/commands/import-media.ts
+++ b/src/commands/import-media.ts
@@ -1,12 +1,14 @@
 import { createHash } from 'crypto';
-import { existsSync, readFileSync, statSync } from 'fs';
-import { basename, extname } from 'path';
+import { existsSync, readFileSync, statSync, mkdtempSync, writeFileSync } from 'fs';
+import { basename, extname, join } from 'path';
+import { tmpdir } from 'os';
 import type { BrainEngine } from '../core/engine.ts';
 import type { ChunkInput, PageInput } from '../core/types.ts';
 import { normalizeMediaExtraction, mediaExtractionToEvidence, type MediaEvidence, type MediaExtraction, type MediaExtractionKind } from '../core/media-extraction.ts';
 import { chunkText } from '../core/chunkers/recursive.ts';
 import { parseMarkdown } from '../core/markdown.ts';
 import { getMimeType, canAttachFiles, attachFileRecordWithEngine, type IngestMediaResult } from './files.ts';
+import { createConfiguredCodexExtractionClient } from '../core/ai/codex-extraction-client.ts';
 
 function usage(): never {
   console.error('Usage: gbrain import-media --slug <slug> --content-file <file.md> --extraction <file.json> [--source <name>] [--raw-data-source <name>] [--media-file <path>] [--title <title>] [--type <kind>] [--no-file] [--no-embed]');
@@ -236,6 +238,58 @@ export async function runImportMedia(engine: BrainEngine, args: string[]) {
   }, null, 2));
 }
 
+async function resolveIngestExtractionFile(mediaFile: string, extractionFile: string, kindHint: string | undefined, title: string | undefined): Promise<string> {
+  if (extractionFile !== 'openclaw') return extractionFile;
+
+  const client = createConfiguredCodexExtractionClient();
+  if (!client) {
+    throw new Error('gbrain ingest-media --extract openclaw requires GBRAIN_OPENCLAW_GATEWAY_URL/OPENCLAW_GATEWAY_URL or GBRAIN_OPENCLAW_COMPLETION_COMMAND');
+  }
+
+  const maxTextBytes = 1_000_000;
+  const size = statSync(mediaFile).size;
+  if (size > maxTextBytes) {
+    throw new Error(`gbrain ingest-media --extract openclaw only supports text inputs up to ${maxTextBytes} bytes; got ${size}`);
+  }
+
+  const inputText = readFileSync(mediaFile, 'utf-8');
+  const inferredKind = kindHint ?? (getMimeType(mediaFile)?.startsWith('audio/') ? 'audio' : getMimeType(mediaFile)?.startsWith('video/') ? 'video' : extname(mediaFile).toLowerCase() === '.pdf' ? 'pdf' : 'pdf');
+  const extraction = await client.completeJson({
+    prompt: buildCodexMediaExtractionPrompt({
+      filename: basename(mediaFile),
+      title,
+      kind: inferredKind,
+      text: inputText,
+    }),
+  });
+  const dir = mkdtempSync(join(tmpdir(), 'gbrain-codex-extraction-'));
+  const out = join(dir, 'extraction.json');
+  writeFileSync(out, JSON.stringify(extraction, null, 2) + '\n');
+  return out;
+}
+
+function buildCodexMediaExtractionPrompt(input: { filename: string; title?: string; kind: string; text: string }): string {
+  return `Extract this text-only media/help document into a JSON object matching gbrain.media-extraction.v1.
+
+Return ONLY JSON. Required shape:
+{
+  "schemaVersion": "gbrain.media-extraction.v1",
+  "kind": "image|pdf|video|audio",
+  "sourceRef": "...",
+  "title": "...",
+  "summary": "...",
+  "segments": [{ "id": "segment-0", "kind": "page|transcript_segment|asset", "summary": "...", "transcriptText": "...", "entities": [{"text":"...","type":"..."}], "tags": [{"value":"..."}] }]
+}
+
+Use kind "${input.kind}" unless the content clearly indicates another allowed media kind. Preserve important quotes and names. Keep segment ids stable and lowercase.
+
+Filename: ${input.filename}
+Title hint: ${input.title ?? '(none)'}
+
+Content:
+${input.text}`;
+}
+
 export async function runIngestMedia(engine: BrainEngine, args: string[]) {
   const mediaFile = args.find(a => !a.startsWith('--'));
   const extractionFile = getFlag(args, '--extract');
@@ -248,13 +302,15 @@ export async function runIngestMedia(engine: BrainEngine, args: string[]) {
 
   const contentFile = getFlag(args, '--content-file');
   if (!mediaFile || !extractionFile) {
-    console.error('Usage: gbrain ingest-media <file> --extract <json> [--slug <s>] [--title <t>] [--source <src>] [--type <kind>] [--content-file <file.md>] [--no-file] [--no-embed]');
+    console.error('Usage: gbrain ingest-media <file> --extract <json|openclaw> [--slug <s>] [--title <t>] [--source <src>] [--type <kind>] [--content-file <file.md>] [--no-file] [--no-embed]');
     process.exit(1);
   }
 
+  const resolvedExtractionFile = await resolveIngestExtractionFile(mediaFile, extractionFile, type, title);
+
   await runImportMedia(engine, [
     '--slug', slug || defaultMediaSlug(mediaFile),
-    '--extraction', extractionFile,
+    '--extraction', resolvedExtractionFile,
     ...(contentFile ? ['--content-file', contentFile] : []),
     '--media-file', mediaFile,
     '--raw-data-source', 'gbrain.media-evidence.v1',

--- a/src/core/ai/codex-extraction-client.ts
+++ b/src/core/ai/codex-extraction-client.ts
@@ -1,0 +1,200 @@
+export const DEFAULT_CODEX_EXTRACTION_MODEL = 'openai-codex/gpt-5.4-mini';
+const DEFAULT_OPENCLAW_COMPLETION_PATH = '/plugins/gbrain/complete';
+
+export interface CodexExtractionRequest {
+  prompt: string;
+  model?: string;
+  signal?: AbortSignal;
+}
+
+export interface CodexExtractionClient {
+  completeText(request: CodexExtractionRequest): Promise<string>;
+  completeJson<T = unknown>(request: CodexExtractionRequest): Promise<T>;
+}
+
+interface CodexExtractionEnv {
+  GBRAIN_OPENCLAW_COMPLETION_COMMAND?: string;
+  GBRAIN_OPENCLAW_GATEWAY_URL?: string;
+  OPENCLAW_GATEWAY_URL?: string;
+  GBRAIN_OPENCLAW_GATEWAY_TOKEN?: string;
+  OPENCLAW_GATEWAY_TOKEN?: string;
+  GBRAIN_OPENCLAW_COMPLETION_PATH?: string;
+  [key: string]: string | undefined;
+}
+
+export function createConfiguredCodexExtractionClient(env: CodexExtractionEnv = process.env): CodexExtractionClient | undefined {
+  const gatewayUrl = (env.GBRAIN_OPENCLAW_GATEWAY_URL ?? env.OPENCLAW_GATEWAY_URL)?.trim();
+  const gatewayToken = (env.GBRAIN_OPENCLAW_GATEWAY_TOKEN ?? env.OPENCLAW_GATEWAY_TOKEN)?.trim();
+  if (gatewayUrl) {
+    return new OpenClawGatewayCodexExtractionClient({
+      gatewayUrl,
+      gatewayToken,
+      path: env.GBRAIN_OPENCLAW_COMPLETION_PATH?.trim() || DEFAULT_OPENCLAW_COMPLETION_PATH,
+    });
+  }
+
+  const command = env.GBRAIN_OPENCLAW_COMPLETION_COMMAND?.trim();
+  return command ? new CommandCodexExtractionClient(command, env) : undefined;
+}
+
+export class OpenClawGatewayCodexExtractionClient implements CodexExtractionClient {
+  constructor(private readonly options: { gatewayUrl: string; gatewayToken?: string; path?: string }) {}
+
+  async completeText(request: CodexExtractionRequest): Promise<string> {
+    const reply = await this.callBridge(request, false);
+    return coerceTextReply(JSON.stringify(reply));
+  }
+
+  async completeJson<T = unknown>(request: CodexExtractionRequest): Promise<T> {
+    const reply = await this.callBridge(request, true);
+    if (isRecord(reply) && reply.json !== undefined) return reply.json as T;
+    return parseCodexJsonReply(JSON.stringify(reply)) as T;
+  }
+
+  private async callBridge(request: CodexExtractionRequest, json: boolean): Promise<unknown> {
+    const url = new URL(this.options.path ?? DEFAULT_OPENCLAW_COMPLETION_PATH, normalizeGatewayUrl(this.options.gatewayUrl));
+    const headers: Record<string, string> = { 'content-type': 'application/json' };
+    if (this.options.gatewayToken) headers.authorization = `Bearer ${this.options.gatewayToken}`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        protocol: 'gbrain.codex-extraction.v1',
+        model: request.model ?? DEFAULT_CODEX_EXTRACTION_MODEL,
+        prompt: request.prompt,
+        json,
+      }),
+      signal: request.signal,
+    });
+    const text = await res.text();
+    if (!res.ok) throw new Error(`OpenClaw completion bridge failed (${res.status}): ${text || res.statusText}`);
+    const parsed = parseJson(text, 'OpenClaw completion bridge returned non-JSON output');
+    if (isRecord(parsed) && parsed.ok === false) throw new Error(`OpenClaw completion bridge failed: ${String(parsed.error ?? 'unknown error')}`);
+    return parsed;
+  }
+}
+
+export class CommandCodexExtractionClient implements CodexExtractionClient {
+  constructor(private readonly command: string, private readonly env: CodexExtractionEnv = process.env) {}
+
+  async completeText(request: CodexExtractionRequest): Promise<string> {
+    const stdout = await this.run(request, 'text');
+    return coerceTextReply(stdout);
+  }
+
+  async completeJson<T = unknown>(request: CodexExtractionRequest): Promise<T> {
+    const stdout = await this.run(request, 'json');
+    return parseCodexJsonReply(stdout) as T;
+  }
+
+  private async run(request: CodexExtractionRequest, responseFormat: 'text' | 'json'): Promise<string> {
+    const payload = JSON.stringify(toHostPayload(request, responseFormat));
+    const proc = Bun.spawn(['sh', '-lc', this.command], {
+      stdin: 'pipe',
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: this.env,
+    });
+
+    await proc.stdin.write(payload);
+    proc.stdin.end();
+    if (request.signal?.aborted) proc.kill();
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    if (exitCode !== 0) {
+      const reason = stderr.trim() || stdout.trim() || `exit ${exitCode}`;
+      throw new Error(`Codex extraction command failed: ${reason}`);
+    }
+    return stdout;
+  }
+}
+
+function normalizeGatewayUrl(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) throw new Error('Missing OpenClaw gateway URL');
+  return trimmed.endsWith('/') ? trimmed : `${trimmed}/`;
+}
+
+function toHostPayload(request: CodexExtractionRequest, responseFormat: 'text' | 'json'): Record<string, unknown> {
+  const modelRef = request.model ?? DEFAULT_CODEX_EXTRACTION_MODEL;
+  const slash = modelRef.indexOf('/');
+  return {
+    protocol: 'gbrain.codex-extraction.v1',
+    provider: 'openai-codex',
+    model: slash === -1 ? modelRef : modelRef.slice(slash + 1),
+    modelRef,
+    responseFormat,
+    prompt: request.prompt,
+    // Deliberately no apiKey/token fields. The host command/plugin must resolve
+    // auth through the OpenClaw runtime for the active user.
+    auth: { mode: 'openclaw-runtime' },
+  };
+}
+
+function coerceTextReply(stdout: string): string {
+  const trimmed = stdout.trim();
+  if (!trimmed) throw new Error('Codex extraction command returned no output');
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (typeof parsed === 'string') return parsed;
+    if (isRecord(parsed)) {
+      if (typeof parsed.text === 'string') return parsed.text;
+      if (typeof parsed.output === 'string') return parsed.output;
+      if (typeof parsed.content === 'string') return parsed.content;
+      if (Array.isArray(parsed.content)) {
+        const text = contentBlocksToText(parsed.content);
+        if (text) return text;
+      }
+      if (Array.isArray(parsed.choices) && isRecord(parsed.choices[0]) && isRecord(parsed.choices[0].message)) {
+        const message = parsed.choices[0].message;
+        if (typeof message.content === 'string') return message.content;
+      }
+    }
+  } catch {
+    return trimmed;
+  }
+
+  throw new Error('Codex extraction command returned JSON without text content');
+}
+
+function parseCodexJsonReply(stdout: string): unknown {
+  const parsed = parseJson(stdout, 'Codex extraction command returned non-JSON output');
+
+  if (isRecord(parsed)) {
+    if (parsed.json !== undefined) return parsed.json;
+    if (typeof parsed.text === 'string') return parseJson(parsed.text, 'Codex extraction text field was not JSON');
+    if (typeof parsed.output === 'string') return parseJson(parsed.output, 'Codex extraction output field was not JSON');
+    if (typeof parsed.content === 'string') return parseJson(parsed.content, 'Codex extraction content field was not JSON');
+    if (Array.isArray(parsed.content)) {
+      const text = contentBlocksToText(parsed.content);
+      if (text) return parseJson(text, 'Codex extraction content blocks were not JSON');
+    }
+  }
+
+  return parsed;
+}
+
+function contentBlocksToText(blocks: unknown[]): string {
+  return blocks
+    .map(block => isRecord(block) && block.type === 'text' && typeof block.text === 'string' ? block.text : '')
+    .filter(Boolean)
+    .join('\n')
+    .trim();
+}
+
+function parseJson(value: string, message: string): unknown {
+  try {
+    return JSON.parse(value.trim());
+  } catch (err) {
+    throw new Error(`${message}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}

--- a/test/codex-extraction-client.test.ts
+++ b/test/codex-extraction-client.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { CommandCodexExtractionClient, OpenClawGatewayCodexExtractionClient, createConfiguredCodexExtractionClient } from '../src/core/ai/codex-extraction-client.ts';
+
+describe('CodexExtractionClient', () => {
+  test('calls the configured host command with a prompt-only payload and no OAuth token material', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-codex-extraction-test-'));
+    const capturePath = join(dir, 'request.json');
+    const profilePath = join(dir, 'auth-profiles.json');
+    writeFileSync(profilePath, JSON.stringify({
+      version: 1,
+      profiles: {
+        'openai-codex:default': {
+          type: 'oauth',
+          provider: 'openai-codex',
+          access: 'oauth-access-token-must-not-be-api-key',
+          refresh: 'oauth-refresh-token-must-not-be-api-key',
+        },
+      },
+    }));
+
+    const command = `node -e "const fs=require('fs');let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>{fs.writeFileSync(process.env.CAPTURE,s);process.stdout.write(JSON.stringify({text:'host text ok'}));});"`;
+    const client = new CommandCodexExtractionClient(command, {
+      ...process.env,
+      CAPTURE: capturePath,
+      GBRAIN_OPENCLAW_AUTH_PROFILES_PATH: profilePath,
+    });
+
+    const text = await client.completeText({ prompt: 'extract the important facts' });
+
+    expect(text).toBe('host text ok');
+    const payload = JSON.parse(readFileSync(capturePath, 'utf-8'));
+    expect(payload.protocol).toBe('gbrain.codex-extraction.v1');
+    expect(payload.provider).toBe('openai-codex');
+    expect(payload.modelRef).toBe('openai-codex/gpt-5.4-mini');
+    expect(payload.prompt).toBe('extract the important facts');
+    expect(payload.auth).toEqual({ mode: 'openclaw-runtime' });
+    expect(payload.apiKey).toBeUndefined();
+    expect(JSON.stringify(payload)).not.toContain('oauth-access-token-must-not-be-api-key');
+    expect(JSON.stringify(payload)).not.toContain('oauth-refresh-token-must-not-be-api-key');
+  });
+
+  test('parses direct JSON extraction output from the host command', async () => {
+    const command = `node -e "process.stdin.resume();process.stdin.on('end',()=>process.stdout.write(JSON.stringify({schemaVersion:'gbrain.media-extraction.v1',kind:'pdf',segments:[{id:'segment-0',kind:'page',summary:'ok'}]})))"`;
+    const client = new CommandCodexExtractionClient(command, process.env);
+
+    const json = await client.completeJson<any>({ prompt: 'extract JSON' });
+
+    expect(json.schemaVersion).toBe('gbrain.media-extraction.v1');
+    expect(json.segments[0].summary).toBe('ok');
+  });
+
+  test('calls the OpenClaw plugin bridge over HTTP when gateway URL is configured', async () => {
+    const requests: Array<{ url: string; init: RequestInit }> = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      requests.push({ url: String(url), init: init ?? {} });
+      return new Response(JSON.stringify({ ok: true, text: '{"schemaVersion":"gbrain.media-extraction.v1","kind":"pdf","segments":[{"id":"segment-0","kind":"page","summary":"ok"}]}' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+    try {
+      const client = new OpenClawGatewayCodexExtractionClient({ gatewayUrl: 'http://127.0.0.1:18789', gatewayToken: 'gateway-token' });
+      const json = await client.completeJson<any>({ prompt: 'extract JSON' });
+
+      expect(json.schemaVersion).toBe('gbrain.media-extraction.v1');
+      expect(requests.length).toBe(1);
+      expect(requests[0].url).toBe('http://127.0.0.1:18789/plugins/gbrain/complete');
+      expect((requests[0].init.headers as Record<string, string>).authorization).toBe('Bearer gateway-token');
+      const body = JSON.parse(String(requests[0].init.body));
+      expect(body.model).toBe('openai-codex/gpt-5.4-mini');
+      expect(body.prompt).toBe('extract JSON');
+      expect(body.apiKey).toBeUndefined();
+      expect(body.token).toBeUndefined();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('factory prefers the OpenClaw gateway bridge, then falls back to command bridge', () => {
+    expect(createConfiguredCodexExtractionClient({})).toBeUndefined();
+    expect(createConfiguredCodexExtractionClient({ GBRAIN_OPENCLAW_COMPLETION_COMMAND: 'cat' })).toBeTruthy();
+    expect(createConfiguredCodexExtractionClient({ GBRAIN_OPENCLAW_GATEWAY_URL: 'http://127.0.0.1:18789' })).toBeTruthy();
+  });
+});

--- a/test/media-cli-smoke.test.ts
+++ b/test/media-cli-smoke.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect } from 'bun:test';
+import { mkdtempSync, writeFileSync, cpSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const repoRoot = new URL('..', import.meta.url).pathname;
+
+async function runCli(args: string[], env: Record<string, string>): Promise<{ stdout: string; stderr: string; code: number }> {
+  const proc = Bun.spawn(['bun', 'run', 'src/cli.ts', ...args], {
+    cwd: repoRoot,
+    env: { ...process.env, ...env },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, code };
+}
+
+describe('media evidence CLI smoke', () => {
+  test('init -> import-media -> ingest-media -> search keeps media evidence searchable without embeddings', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-media-cli-'));
+    const home = join(dir, 'home');
+    const env = { HOME: home, GBRAIN_HOME: home };
+    const mediaPath = join(dir, 'receipt.png');
+    const extractionPath = join(dir, 'receipt.extraction.json');
+    const contentPath = join(dir, 'custom.md');
+
+    try {
+      writeFileSync(mediaPath, 'fake-image-binary');
+      cpSync(join(repoRoot, 'test/fixtures/media-extraction-image.json'), extractionPath);
+      writeFileSync(contentPath, `---\ntype: media\ntitle: Custom Receipt Page\ncustom_flag: preserved\n---\n\nCurated custom receipt narrative.\n`);
+
+      let result = await runCli(['init', '--pglite'], env);
+      expect(result.code).toBe(0);
+
+      result = await runCli([
+        'import-media',
+        '--slug', 'media/evidence/receipt',
+        '--content-file', contentPath,
+        '--extraction', extractionPath,
+        '--media-file', mediaPath,
+        '--no-embed',
+      ], env);
+      expect(result.code).toBe(0);
+      const imported = JSON.parse(result.stdout);
+      expect(imported.status).toBe('imported');
+      expect(imported.slug).toBe('media/evidence/receipt');
+      expect(imported.raw_data_source).toBe('gbrain.media-evidence.v1');
+      expect(imported.no_embed).toBe(true);
+
+      result = await runCli([
+        'ingest-media',
+        mediaPath,
+        '--extract', extractionPath,
+        '--slug', 'media/evidence/receipt',
+        '--title', 'Custom Receipt Page',
+      ], env);
+      expect(result.code).toBe(0);
+      const ingested = JSON.parse(result.stdout);
+      expect(ingested.status).toBe('imported');
+      expect(ingested.slug).toBe('media/evidence/receipt');
+
+      result = await runCli(['search', 'Stripe'], env);
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('media/evidence/receipt');
+      expect(result.stdout).toContain('Stripe login error screenshot');
+
+      result = await runCli(['search', 'Curated custom receipt narrative'], env);
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('media/evidence/receipt');
+
+      result = await runCli(['stats'], env);
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('Pages:     1');
+      expect(result.stdout).toContain('Chunks:    1');
+      expect(result.stdout).toContain('Embedded:  0');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 60_000);
+});

--- a/test/media-extraction.test.ts
+++ b/test/media-extraction.test.ts
@@ -35,15 +35,15 @@ describe('media evidence import', () => {
   beforeAll(async () => {
     await engine.connect({});
     await engine.initSchema();
-  });
+  }, 30000);
 
   beforeEach(async () => {
     await resetPgliteState(engine);
-  });
+  }, 30000);
 
   afterAll(async () => {
     await engine.disconnect();
-  });
+  }, 30000);
 
   test('stores normalized media evidence as raw_data sidecar', async () => {
     const content = `---\ntype: media\ntitle: Stripe login screenshot\n---\n\nStripe login screenshot evidence.`;
@@ -79,7 +79,7 @@ describe('media evidence import', () => {
       rmSync(dir, { recursive: true, force: true });
     }
 
-    const raw = await engine.getRawData('media/demo-video', 'media-extraction');
+    const raw = await engine.getRawData('media/demo-video', 'gbrain.media-evidence.v1');
     expect(raw.length).toBe(1);
     const data = raw[0]?.data as any;
     expect(data.kind).toBe('video');

--- a/test/media-extraction.test.ts
+++ b/test/media-extraction.test.ts
@@ -79,6 +79,11 @@ describe('media evidence import', () => {
       rmSync(dir, { recursive: true, force: true });
     }
 
+    const page = await engine.getPage('media/demo-video');
+    expect(page?.title).toBe('Demo video');
+    expect(page?.compiled_truth).toBe('Demo video evidence page.');
+    expect(page?.frontmatter.evidence_schema).toBe('gbrain.media-evidence.v1');
+
     const raw = await engine.getRawData('media/demo-video', 'gbrain.media-evidence.v1');
     expect(raw.length).toBe(1);
     const data = raw[0]?.data as any;

--- a/test/media-ingest.test.ts
+++ b/test/media-ingest.test.ts
@@ -87,6 +87,39 @@ describe('ingest-media normalized integration', () => {
     }
   }, 30000);
 
+  test('can generate text-only extraction through GBRAIN_OPENCLAW_COMPLETION_COMMAND', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-ingest-media-openclaw-'));
+    const mediaPath = join(dir, 'help-doc.md');
+    const capturePath = join(dir, 'openclaw-request.json');
+    const prevCommand = process.env.GBRAIN_OPENCLAW_COMPLETION_COMMAND;
+    writeFileSync(mediaPath, '# Help Doc\n\nOpenClaw supports host-routed Codex extraction.');
+    process.env.GBRAIN_OPENCLAW_COMPLETION_COMMAND = `node -e "const fs=require('fs');let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>{fs.writeFileSync(process.env.CAPTURE,s);process.stdout.write(JSON.stringify({schemaVersion:'gbrain.media-extraction.v1',kind:'pdf',title:'Help Doc',summary:'Host-routed extraction.',segments:[{id:'segment-0',kind:'page',summary:'Codex extraction works',transcriptText:'OpenClaw supports host-routed Codex extraction.'}]}));});"`;
+    process.env.CAPTURE = capturePath;
+
+    let payload: any;
+    try {
+      await runIngestMedia(engine, [
+        mediaPath,
+        '--extract', 'openclaw',
+        '--slug', 'media/evidence/help-doc',
+        '--title', 'Help Doc',
+        '--no-file',
+      ]);
+      payload = JSON.parse(readFileSync(capturePath, 'utf-8'));
+    } finally {
+      if (prevCommand === undefined) delete process.env.GBRAIN_OPENCLAW_COMPLETION_COMMAND;
+      else process.env.GBRAIN_OPENCLAW_COMPLETION_COMMAND = prevCommand;
+      delete process.env.CAPTURE;
+      rmSync(dir, { recursive: true, force: true });
+    }
+
+    const page = await engine.getPage('media/evidence/help-doc');
+    expect(page?.compiled_truth).toContain('OpenClaw supports host-routed Codex extraction.');
+    expect(payload.modelRef).toBe('openai-codex/gpt-5.4-mini');
+    expect(payload.prompt).toContain('Help Doc');
+    expect(payload.apiKey).toBeUndefined();
+  }, 30000);
+
   test('updates page when frontmatter changes even if evidence and body are unchanged', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'gbrain-ingest-media-frontmatter-'));
     const mediaPath = join(dir, 'receipt.png');

--- a/test/media-ingest.test.ts
+++ b/test/media-ingest.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { ingestMediaEvidence } from '../src/commands/files.ts';
+
+async function makeEngine() {
+  const dir = mkdtempSync(join(tmpdir(), 'gbrain-media-ingest-'));
+  const engine = new PGLiteEngine();
+  await engine.connect({ engine: 'pglite', database_path: dir });
+  await engine.initSchema();
+  return { engine, dir };
+}
+
+describe('ingestMediaEvidence', () => {
+  test('creates media page, raw_data, file record, and searchable text', async () => {
+    const { engine, dir } = await makeEngine();
+    try {
+      const mediaPath = join(dir, 'receipt.png');
+      const extractionPath = join(dir, 'receipt.extraction.json');
+      writeFileSync(mediaPath, 'fake-image-binary');
+      writeFileSync(extractionPath, JSON.stringify({
+        caption: 'Receipt on wooden table',
+        ocr_text: 'Total: $42.50\nMerchant: Example Store',
+        transcript: '',
+      }));
+
+      const result = await ingestMediaEvidence(engine, {
+        path: mediaPath,
+        extractionPath,
+        slug: 'media/evidence/receipt',
+        title: 'Store receipt',
+        source: 'fixture-extractor',
+      });
+
+      expect(result.slug).toBe('media/evidence/receipt');
+      expect(result.fileAttached).toBe(false);
+      expect(result.storagePath).toBe('media/evidence/receipt/receipt.png');
+
+      const page = await engine.getPage('media/evidence/receipt');
+      expect(page).toBeTruthy();
+      expect(page?.type).toBe('media');
+      expect(page?.title).toBe('Store receipt');
+      expect(page?.compiled_truth).toContain('Receipt on wooden table');
+      expect(page?.compiled_truth).toContain('Total: $42.50');
+      expect(page?.frontmatter.media_type).toBe('image');
+
+      const raw = await engine.getRawData('media/evidence/receipt', 'fixture-extractor');
+      expect(raw.length).toBe(1);
+      expect((raw[0].data as any).extraction.ocr_text).toContain('Total: $42.50');
+
+      const chunks = await engine.getChunks('media/evidence/receipt');
+      expect(chunks.length).toBeGreaterThan(0);
+      expect(chunks.some(c => c.chunk_text.includes('Example Store'))).toBe(true);
+      expect(result.storagePath).toBe('media/evidence/receipt/receipt.png');
+    } finally {
+      await engine.disconnect();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 30000);
+
+  test('fails when extraction has no searchable text', async () => {
+    const { engine, dir } = await makeEngine();
+    try {
+      const mediaPath = join(dir, 'empty.pdf');
+      const extractionPath = join(dir, 'empty.extraction.json');
+      writeFileSync(mediaPath, 'fake-pdf-binary');
+      writeFileSync(extractionPath, JSON.stringify({ pages: [{ width: 100, height: 100 }] }));
+
+      await expect(ingestMediaEvidence(engine, {
+        path: mediaPath,
+        extractionPath,
+      })).rejects.toThrow('Extraction JSON did not contain searchable text');
+    } finally {
+      await engine.disconnect();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 30000);
+});

--- a/test/media-ingest.test.ts
+++ b/test/media-ingest.test.ts
@@ -39,6 +39,19 @@ describe('ingest-media normalized integration', () => {
         '--slug', 'media/evidence/receipt',
         '--title', 'Store receipt',
       ]);
+
+      const versionsBefore = await engine.getVersions('media/evidence/receipt');
+      const ingestLogBefore = await engine.getIngestLog({ limit: 10 });
+      await runIngestMedia(engine, [
+        mediaPath,
+        '--extract', extractionPath,
+        '--slug', 'media/evidence/receipt',
+        '--title', 'Store receipt',
+      ]);
+      const versionsAfter = await engine.getVersions('media/evidence/receipt');
+      const ingestLogAfter = await engine.getIngestLog({ limit: 10 });
+      expect(versionsAfter.length).toBe(versionsBefore.length);
+      expect(ingestLogAfter.length).toBe(ingestLogBefore.length);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -63,6 +76,7 @@ describe('ingest-media normalized integration', () => {
     const chunks = await engine.getChunks('media/evidence/receipt');
     expect(chunks.length).toBeGreaterThan(0);
     expect(chunks.some(c => c.chunk_text.includes('Stripe API key invalid'))).toBe(true);
+    expect(chunks.every(c => c.embedding === null)).toBe(true);
 
     const filesTableAvailable = await engine.executeRaw<{ exists: boolean }>(
       `SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='files') AS exists`,

--- a/test/media-ingest.test.ts
+++ b/test/media-ingest.test.ts
@@ -1,80 +1,75 @@
-import { describe, test, expect } from 'bun:test';
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
-import { ingestMediaEvidence } from '../src/commands/files.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { runIngestMedia } from '../src/commands/import-media.ts';
 
-async function makeEngine() {
-  const dir = mkdtempSync(join(tmpdir(), 'gbrain-media-ingest-'));
+const FIXTURES = join(import.meta.dir, 'fixtures');
+
+describe('ingest-media normalized integration', () => {
   const engine = new PGLiteEngine();
-  await engine.connect({ engine: 'pglite', database_path: dir });
-  await engine.initSchema();
-  return { engine, dir };
-}
 
-describe('ingestMediaEvidence', () => {
-  test('creates media page, raw_data, file record, and searchable text', async () => {
-    const { engine, dir } = await makeEngine();
+  beforeAll(async () => {
+    await engine.connect({});
+    await engine.initSchema();
+  });
+
+  beforeEach(async () => {
+    await resetPgliteState(engine);
+  });
+
+  afterAll(async () => {
+    await engine.disconnect();
+  });
+
+  test('routes ingest-media through normalized evidence and materializes page/raw_data/chunks', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-ingest-media-'));
+    const mediaPath = join(dir, 'receipt.png');
+    const extractionPath = join(dir, 'receipt.extraction.json');
+    writeFileSync(mediaPath, 'fake-image-binary');
+    writeFileSync(extractionPath, readFileSync(join(FIXTURES, 'media-extraction-image.json'), 'utf-8'));
+
     try {
-      const mediaPath = join(dir, 'receipt.png');
-      const extractionPath = join(dir, 'receipt.extraction.json');
-      writeFileSync(mediaPath, 'fake-image-binary');
-      writeFileSync(extractionPath, JSON.stringify({
-        caption: 'Receipt on wooden table',
-        ocr_text: 'Total: $42.50\nMerchant: Example Store',
-        transcript: '',
-      }));
-
-      const result = await ingestMediaEvidence(engine, {
-        path: mediaPath,
-        extractionPath,
-        slug: 'media/evidence/receipt',
-        title: 'Store receipt',
-        source: 'fixture-extractor',
-      });
-
-      expect(result.slug).toBe('media/evidence/receipt');
-      expect(result.fileAttached).toBe(false);
-      expect(result.storagePath).toBe('media/evidence/receipt/receipt.png');
-
-      const page = await engine.getPage('media/evidence/receipt');
-      expect(page).toBeTruthy();
-      expect(page?.type).toBe('media');
-      expect(page?.title).toBe('Store receipt');
-      expect(page?.compiled_truth).toContain('Receipt on wooden table');
-      expect(page?.compiled_truth).toContain('Total: $42.50');
-      expect(page?.frontmatter.media_type).toBe('image');
-
-      const raw = await engine.getRawData('media/evidence/receipt', 'fixture-extractor');
-      expect(raw.length).toBe(1);
-      expect((raw[0].data as any).extraction.ocr_text).toContain('Total: $42.50');
-
-      const chunks = await engine.getChunks('media/evidence/receipt');
-      expect(chunks.length).toBeGreaterThan(0);
-      expect(chunks.some(c => c.chunk_text.includes('Example Store'))).toBe(true);
-      expect(result.storagePath).toBe('media/evidence/receipt/receipt.png');
+      await runIngestMedia(engine, [
+        mediaPath,
+        '--extract', extractionPath,
+        '--slug', 'media/evidence/receipt',
+        '--title', 'Store receipt',
+      ]);
     } finally {
-      await engine.disconnect();
       rmSync(dir, { recursive: true, force: true });
     }
-  }, 30000);
 
-  test('fails when extraction has no searchable text', async () => {
-    const { engine, dir } = await makeEngine();
-    try {
-      const mediaPath = join(dir, 'empty.pdf');
-      const extractionPath = join(dir, 'empty.extraction.json');
-      writeFileSync(mediaPath, 'fake-pdf-binary');
-      writeFileSync(extractionPath, JSON.stringify({ pages: [{ width: 100, height: 100 }] }));
+    const page = await engine.getPage('media/evidence/receipt');
+    expect(page).toBeTruthy();
+    expect(page?.type).toBe('media');
+    expect(page?.title).toBe('Store receipt');
+    expect(page?.frontmatter.evidence_schema).toBe('gbrain.media-evidence.v1');
+    expect(page?.frontmatter.media_type).toBe('image');
+    expect(page?.compiled_truth).toContain('Stripe API key invalid');
 
-      await expect(ingestMediaEvidence(engine, {
-        path: mediaPath,
-        extractionPath,
-      })).rejects.toThrow('Extraction JSON did not contain searchable text');
-    } finally {
-      await engine.disconnect();
-      rmSync(dir, { recursive: true, force: true });
+    const raw = await engine.getRawData('media/evidence/receipt', 'gbrain.media-evidence.v1');
+    expect(raw.length).toBe(1);
+    const data = raw[0]?.data as any;
+    expect(data.schemaVersion).toBe('gbrain.media-evidence.v1');
+    expect(data.kind).toBe('image');
+    expect(data.sourceRef).toContain('receipt.png');
+    expect(data.segments.length).toBeGreaterThan(0);
+    expect(data.segments[0].locator.bbox).toEqual([0.1, 0.2, 0.8, 0.35]);
+
+    const chunks = await engine.getChunks('media/evidence/receipt');
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks.some(c => c.chunk_text.includes('Stripe API key invalid'))).toBe(true);
+
+    const filesTableAvailable = await engine.executeRaw<{ exists: boolean }>(
+      `SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='files') AS exists`,
+    );
+    if (!filesTableAvailable[0]?.exists) {
+      expect(page?.frontmatter.filename).toBe('receipt.png');
+      expect(page?.frontmatter.mime_type).toBe('image/png');
     }
   }, 30000);
 });

--- a/test/media-ingest.test.ts
+++ b/test/media-ingest.test.ts
@@ -86,4 +86,43 @@ describe('ingest-media normalized integration', () => {
       expect(page?.frontmatter.mime_type).toBe('image/png');
     }
   }, 30000);
+
+  test('updates page when frontmatter changes even if evidence and body are unchanged', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-ingest-media-frontmatter-'));
+    const mediaPath = join(dir, 'receipt.png');
+    const extractionPath = join(dir, 'receipt.extraction.json');
+    const firstContent = join(dir, 'first.md');
+    const secondContent = join(dir, 'second.md');
+    writeFileSync(mediaPath, 'fake-image-binary');
+    writeFileSync(extractionPath, readFileSync(join(FIXTURES, 'media-extraction-image.json'), 'utf-8'));
+    writeFileSync(firstContent, '---\ntitle: Store receipt\nreviewed: false\n---\n\nSame curated receipt narrative.\n');
+    writeFileSync(secondContent, '---\ntitle: Store receipt\nreviewed: true\n---\n\nSame curated receipt narrative.\n');
+
+    try {
+      await runIngestMedia(engine, [
+        mediaPath,
+        '--extract', extractionPath,
+        '--slug', 'media/evidence/receipt',
+        '--title', 'Store receipt',
+        '--content-file', firstContent,
+      ]);
+      const before = await engine.getPage('media/evidence/receipt');
+      expect(before?.frontmatter.reviewed).toBe(false);
+
+      await runIngestMedia(engine, [
+        mediaPath,
+        '--extract', extractionPath,
+        '--slug', 'media/evidence/receipt',
+        '--title', 'Store receipt',
+        '--content-file', secondContent,
+      ]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+
+    const after = await engine.getPage('media/evidence/receipt');
+    expect(after?.frontmatter.reviewed).toBe(true);
+    const versions = await engine.getVersions('media/evidence/receipt');
+    expect(versions.length).toBe(1);
+  }, 30000);
 });


### PR DESCRIPTION
Successor to #15 (auto-closed when its base \`feat/issue-10\` was deleted on PR #14 squash-merge).

Rebased onto current \`master\` (post-PR #14 squash + PR #20 merge). Same 6 commits, replayed cleanly.

## Scope

Media-only stack on top of the now-merged normalized media extraction boundary:
- \`gbrain ingest-media\` CLI command
- Media evidence ingest MVP + idempotency hardening
- \`ingest-media\` aligned with normalized evidence API
- Media evidence CLI smoke gate (test/media-cli-smoke.test.ts)
- Optional OpenClaw media extraction bridge (text-only extraction client)

## Conflict resolutions during rebase onto master

\`src/cli.ts\` — three drift conflicts vs current master:
1. \`CLI_ONLY\` set: kept master's \`'providers'\` (from PR #20), kept PR #14's \`'import-media'\`, added \`'ingest-media'\`.
2. Help text: kept both \`import-media\` and \`ingest-media\` lines.
3. Aligned with the post-rebase command set.

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun test test/media-ingest.test.ts test/media-extraction.test.ts test/media-cli-smoke.test.ts test/codex-extraction-client.test.ts\` — **12 pass / 0 fail / 91 expects**
- [x] \`bun install --frozen-lockfile\` — clean
- [x] \`bun run build:llms\` — no diff (llms.txt/llms-full.txt up to date)
- [ ] CI — full E2E + LLM skills (will run after this PR opens)

Closes #15.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `ingest-media` CLI command for importing normalized media evidence.
  * Added support for attaching media files with `--media-file`, `--title`, and `--type` flags.
  * Added `--no-file` flag to skip file attachment during import.
  * Integrated AI-powered extraction service for automated content processing from media files.

* **Improvements**
  * Enhanced media evidence import with change detection and conflict-safe metadata updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->