### PR TITLE
Support Voyage 2048d setup and source-aware sync

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1434,7 +1434,8 @@ This is the dispatcher. Skills are the implementation. **Read the skill file bef
 | Where does a new file go? Filing rules | `skills/repo-architecture/SKILL.md` |
 | Fix broken citations in brain pages | `skills/citation-fixer/SKILL.md` |
 | "citation audit", "check citations", "fix citations" | `skills/citation-fixer/SKILL.md` (focused fix). For broader brain health, chain into `skills/maintain/SKILL.md` |
-| "Research", "track", "extract from email", "investor updates", "donations" | `skills/data-research/SKILL.md` |
+| "data research", "track", "extract from email", "investor updates", "donations" | `skills/data-research/SKILL.md` |
+| "perplexity research", "what's new about", "current state of", "web research", "what changed about" | `skills/perplexity-research/SKILL.md` |
 | Share a brain page as a link | `skills/publish/SKILL.md` |
 | "validate frontmatter", "check frontmatter", "fix frontmatter", "frontmatter audit", "brain lint" | `skills/frontmatter-guard/SKILL.md` |
 
@@ -1443,7 +1444,8 @@ This is the dispatcher. Skills are the implementation. **Read the skill file bef
 | Trigger | Skill |
 |---------|-------|
 | User shares a link, article, tweet, or idea | `skills/idea-ingest/SKILL.md` |
-| Video, audio, PDF, book, YouTube, screenshot | `skills/media-ingest/SKILL.md` |
+| "watch this video", "process this YouTube link", "ingest this PDF", "save this podcast", "process this book", "what's in this screenshot", "check out this repo", "summarize this book" | `skills/media-ingest/SKILL.md` |
+| "voice note", "ingest this voice memo", "transcribe and file", "voice note ingest", "save this audio note" | `skills/voice-note-ingest/SKILL.md` |
 | Meeting transcript received | `skills/meeting-ingestion/SKILL.md` |
 | Generic "ingest this" (auto-routes to above) | `skills/ingest/SKILL.md` |
 
@@ -1525,20 +1527,28 @@ These apply to ALL brain-writing skills:
 | Trigger | Skill |
 |---------|-------|
 | "personalized version of this book" | `skills/book-mirror/SKILL.md` |
+| "mirror this book", "two-column book analysis", "apply this book to my life", "how does this book apply to me" | `skills/book-mirror/SKILL.md` |
 
 | "enrich this article" | `skills/article-enrichment/SKILL.md` |
+| "enrich brain pages", "batch enrich", "make brain pages useful" | `skills/article-enrichment/SKILL.md` |
 
 | "strategic reading" | `skills/strategic-reading/SKILL.md` |
+| "read this through the lens of", "apply this to my problem", "what can I learn from this about", "extract a playbook from" | `skills/strategic-reading/SKILL.md` |
 
 | "concept synthesis" | `skills/concept-synthesis/SKILL.md` |
+| "synthesize my concepts", "find patterns across my notes", "build my intellectual map", "trace idea evolution" | `skills/concept-synthesis/SKILL.md` |
 
 | "perplexity research" | `skills/perplexity-research/SKILL.md` |
+| "what's new about", "current state of", "web research", "what changed about" | `skills/perplexity-research/SKILL.md` |
 
 | "crawl my archive" | `skills/archive-crawler/SKILL.md` |
+| "find gold in my archive", "archive crawler", "scan my dropbox for", "mine my old files for" | `skills/archive-crawler/SKILL.md` |
 
 | "verify this academic claim" | `skills/academic-verify/SKILL.md` |
+| "check this study", "academic verify", "validate citation", "is this study real" | `skills/academic-verify/SKILL.md` |
 
 | "make pdf from brain" | `skills/brain-pdf/SKILL.md` |
+| "brain pdf", "convert brain page to pdf", "publish this page as pdf", "export brain page" | `skills/brain-pdf/SKILL.md` |
 
 | "voice note" | `skills/voice-note-ingest/SKILL.md` |
 

--- a/skills/RESOLVER.md
+++ b/skills/RESOLVER.md
@@ -19,7 +19,8 @@ This is the dispatcher. Skills are the implementation. **Read the skill file bef
 | Where does a new file go? Filing rules | `skills/repo-architecture/SKILL.md` |
 | Fix broken citations in brain pages | `skills/citation-fixer/SKILL.md` |
 | "citation audit", "check citations", "fix citations" | `skills/citation-fixer/SKILL.md` (focused fix). For broader brain health, chain into `skills/maintain/SKILL.md` |
-| "Research", "track", "extract from email", "investor updates", "donations" | `skills/data-research/SKILL.md` |
+| "data research", "track", "extract from email", "investor updates", "donations" | `skills/data-research/SKILL.md` |
+| "perplexity research", "what's new about", "current state of", "web research", "what changed about" | `skills/perplexity-research/SKILL.md` |
 | Share a brain page as a link | `skills/publish/SKILL.md` |
 | "validate frontmatter", "check frontmatter", "fix frontmatter", "frontmatter audit", "brain lint" | `skills/frontmatter-guard/SKILL.md` |
 
@@ -28,7 +29,8 @@ This is the dispatcher. Skills are the implementation. **Read the skill file bef
 | Trigger | Skill |
 |---------|-------|
 | User shares a link, article, tweet, or idea | `skills/idea-ingest/SKILL.md` |
-| Video, audio, PDF, book, YouTube, screenshot | `skills/media-ingest/SKILL.md` |
+| "watch this video", "process this YouTube link", "ingest this PDF", "save this podcast", "process this book", "what's in this screenshot", "check out this repo", "summarize this book" | `skills/media-ingest/SKILL.md` |
+| "voice note", "ingest this voice memo", "transcribe and file", "voice note ingest", "save this audio note" | `skills/voice-note-ingest/SKILL.md` |
 | Meeting transcript received | `skills/meeting-ingestion/SKILL.md` |
 | Generic "ingest this" (auto-routes to above) | `skills/ingest/SKILL.md` |
 
@@ -110,19 +112,27 @@ These apply to ALL brain-writing skills:
 | Trigger | Skill |
 |---------|-------|
 | "personalized version of this book" | `skills/book-mirror/SKILL.md` |
+| "mirror this book", "two-column book analysis", "apply this book to my life", "how does this book apply to me" | `skills/book-mirror/SKILL.md` |
 
 | "enrich this article" | `skills/article-enrichment/SKILL.md` |
+| "enrich brain pages", "batch enrich", "make brain pages useful" | `skills/article-enrichment/SKILL.md` |
 
 | "strategic reading" | `skills/strategic-reading/SKILL.md` |
+| "read this through the lens of", "apply this to my problem", "what can I learn from this about", "extract a playbook from" | `skills/strategic-reading/SKILL.md` |
 
 | "concept synthesis" | `skills/concept-synthesis/SKILL.md` |
+| "synthesize my concepts", "find patterns across my notes", "build my intellectual map", "trace idea evolution" | `skills/concept-synthesis/SKILL.md` |
 
 | "perplexity research" | `skills/perplexity-research/SKILL.md` |
+| "what's new about", "current state of", "web research", "what changed about" | `skills/perplexity-research/SKILL.md` |
 
 | "crawl my archive" | `skills/archive-crawler/SKILL.md` |
+| "find gold in my archive", "archive crawler", "scan my dropbox for", "mine my old files for" | `skills/archive-crawler/SKILL.md` |
 
 | "verify this academic claim" | `skills/academic-verify/SKILL.md` |
+| "check this study", "academic verify", "validate citation", "is this study real" | `skills/academic-verify/SKILL.md` |
 
 | "make pdf from brain" | `skills/brain-pdf/SKILL.md` |
+| "brain pdf", "convert brain page to pdf", "publish this page as pdf", "export brain page" | `skills/brain-pdf/SKILL.md` |
 
 | "voice note" | `skills/voice-note-ingest/SKILL.md` |

--- a/skills/media-ingest/SKILL.md
+++ b/skills/media-ingest/SKILL.md
@@ -13,6 +13,7 @@ triggers:
   - "process this book"
   - "what's in this screenshot"
   - "check out this repo"
+  - "summarize this book"
 tools:
   - search
   - query

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -322,16 +322,24 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
 
   // 4. pgvector extension
   progress.heartbeat('pgvector');
-  try {
-    const sql = db.getConnection();
-    const ext = await sql`SELECT extname FROM pg_extension WHERE extname = 'vector'`;
-    if (ext.length > 0) {
-      checks.push({ name: 'pgvector', status: 'ok', message: 'Extension installed' });
-    } else {
-      checks.push({ name: 'pgvector', status: 'fail', message: 'Extension not found. Run: CREATE EXTENSION vector;' });
+  if (engine.kind === 'pglite') {
+    checks.push({
+      name: 'pgvector',
+      status: 'ok',
+      message: 'PGLite vector support active (validated by schema + embedding checks)',
+    });
+  } else {
+    try {
+      const sql = db.getConnection();
+      const ext = await sql`SELECT extname FROM pg_extension WHERE extname = 'vector'`;
+      if (ext.length > 0) {
+        checks.push({ name: 'pgvector', status: 'ok', message: 'Extension installed' });
+      } else {
+        checks.push({ name: 'pgvector', status: 'fail', message: 'Extension not found. Run: CREATE EXTENSION vector;' });
+      }
+    } catch {
+      checks.push({ name: 'pgvector', status: 'warn', message: 'Could not check pgvector extension' });
     }
-  } catch {
-    checks.push({ name: 'pgvector', status: 'warn', message: 'Could not check pgvector extension' });
   }
 
   // 4b. PgBouncer / prepared-statement compatibility.
@@ -522,7 +530,13 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
     const health = await engine.getHealth();
     const linkPct = ((health.link_coverage ?? 0) * 100).toFixed(0);
     const timelinePct = ((health.timeline_coverage ?? 0) * 100).toFixed(0);
-    if ((health.link_coverage ?? 0) >= 0.5 && (health.timeline_coverage ?? 0) >= 0.5) {
+    if (health.entity_page_count === 0) {
+      checks.push({
+        name: 'graph_coverage',
+        status: 'ok',
+        message: 'No person/company entity pages yet; entity graph coverage not applicable',
+      });
+    } else if ((health.link_coverage ?? 0) >= 0.5 && (health.timeline_coverage ?? 0) >= 0.5) {
       checks.push({ name: 'graph_coverage', status: 'ok', message: `Entity link coverage ${linkPct}%, timeline ${timelinePct}%` });
     } else {
       checks.push({
@@ -599,36 +613,44 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
   // surface matches `repair-jsonb` (the previous 4-target scan missed a
   // repair target, per #254/Codex review).
   progress.heartbeat('jsonb_integrity');
-  try {
-    const sql = db.getConnection();
-    const targets: Array<{ table: string; col: string; expected: 'object' | 'array' }> = [
-      { table: 'pages',         col: 'frontmatter',    expected: 'object' },
-      { table: 'raw_data',      col: 'data',           expected: 'object' },
-      { table: 'ingest_log',    col: 'pages_updated',  expected: 'array'  },
-      { table: 'files',         col: 'metadata',       expected: 'object' },
-      { table: 'page_versions', col: 'frontmatter',    expected: 'object' },
-    ];
-    let totalBad = 0;
-    const breakdown: string[] = [];
-    for (const { table, col } of targets) {
-      progress.heartbeat(`jsonb_integrity.${table}.${col}`);
-      const rows = await sql.unsafe(
-        `SELECT count(*)::int AS n FROM ${table} WHERE jsonb_typeof(${col}) = 'string'`,
-      );
-      const n = Number((rows as any)[0]?.n ?? 0);
-      if (n > 0) { totalBad += n; breakdown.push(`${table}.${col}=${n}`); }
+  if (engine.kind === 'pglite') {
+    checks.push({
+      name: 'jsonb_integrity',
+      status: 'ok',
+      message: 'Skipped (PGLite stores JSON locally; Postgres JSONB repair check not applicable)',
+    });
+  } else {
+    try {
+      const sql = db.getConnection();
+      const targets: Array<{ table: string; col: string; expected: 'object' | 'array' }> = [
+        { table: 'pages',         col: 'frontmatter',    expected: 'object' },
+        { table: 'raw_data',      col: 'data',           expected: 'object' },
+        { table: 'ingest_log',    col: 'pages_updated',  expected: 'array'  },
+        { table: 'files',         col: 'metadata',       expected: 'object' },
+        { table: 'page_versions', col: 'frontmatter',    expected: 'object' },
+      ];
+      let totalBad = 0;
+      const breakdown: string[] = [];
+      for (const { table, col } of targets) {
+        progress.heartbeat(`jsonb_integrity.${table}.${col}`);
+        const rows = await sql.unsafe(
+          `SELECT count(*)::int AS n FROM ${table} WHERE jsonb_typeof(${col}) = 'string'`,
+        );
+        const n = Number((rows as any)[0]?.n ?? 0);
+        if (n > 0) { totalBad += n; breakdown.push(`${table}.${col}=${n}`); }
+      }
+      if (totalBad === 0) {
+        checks.push({ name: 'jsonb_integrity', status: 'ok', message: 'All JSONB columns store objects/arrays' });
+      } else {
+        checks.push({
+          name: 'jsonb_integrity',
+          status: 'warn',
+          message: `${totalBad} row(s) double-encoded (${breakdown.join(', ')}). Fix: gbrain repair-jsonb`,
+        });
+      }
+    } catch {
+      checks.push({ name: 'jsonb_integrity', status: 'warn', message: 'Could not check JSONB integrity' });
     }
-    if (totalBad === 0) {
-      checks.push({ name: 'jsonb_integrity', status: 'ok', message: 'All JSONB columns store objects/arrays' });
-    } else {
-      checks.push({
-        name: 'jsonb_integrity',
-        status: 'warn',
-        message: `${totalBad} row(s) double-encoded (${breakdown.join(', ')}). Fix: gbrain repair-jsonb`,
-      });
-    }
-  } catch {
-    checks.push({ name: 'jsonb_integrity', status: 'warn', message: 'Could not check JSONB integrity' });
   }
 
   // 11. Markdown body completeness (v0.12.3 reliability wave).

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -28,7 +28,11 @@ export interface RunImportResult {
   failures: Array<{ path: string; error: string }>;
 }
 
-export async function runImport(engine: BrainEngine, args: string[], opts: { commit?: string } = {}): Promise<RunImportResult> {
+export async function runImport(
+  engine: BrainEngine,
+  args: string[],
+  opts: { commit?: string; sourceId?: string } = {},
+): Promise<RunImportResult> {
   const noEmbed = args.includes('--no-embed');
   const fresh = args.includes('--fresh');
   const jsonOutput = args.includes('--json');
@@ -105,7 +109,7 @@ export async function runImport(engine: BrainEngine, args: string[], opts: { com
   async function processFile(eng: BrainEngine, filePath: string) {
     const relativePath = relative(dir, filePath);
     try {
-      const result = await importFile(eng, filePath, relativePath, { noEmbed });
+      const result = await importFile(eng, filePath, relativePath, { noEmbed, sourceId: opts.sourceId });
       if (result.status === 'imported') {
         imported++;
         chunksCreated += result.chunks;

--- a/src/commands/integrity.ts
+++ b/src/commands/integrity.ts
@@ -65,7 +65,7 @@ const BARE_TWEET_PHRASES = [
   /\bon (?:a |the )?(?:recent |viral )?tweet\b/i,
   /\bwrote (?:a |the )?(?:tweet|post)\b/i,
   /\bposted on X\b/i,
-  /\bvia X\b(?!\s*\/)/i, // "via X" but not "via X/handle" (already cited)
+  /\bvia X\b(?!\s*(?:\/|API\b))/i, // "via X" but not "via X/handle" or "via X API"
   /\bhis (?:recent |)tweet\b/i,
   /\bher (?:recent |)tweet\b/i,
   /\btheir (?:recent |)tweet\b/i,

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -524,7 +524,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       // Reimport at new path (picks up content changes)
       const filePath = join(repoPath, to);
       if (existsSync(filePath)) {
-        const result = await importFile(engine, filePath, to, { noEmbed });
+        const result = await importFile(engine, filePath, to, { noEmbed, sourceId: opts.sourceId });
         if (result.status === 'imported') chunksCreated += result.chunks;
       }
       pagesAffected.push(newSlug);
@@ -579,7 +579,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
         return;
       }
       try {
-        const result = await importFile(eng, filePath, path, { noEmbed });
+        const result = await importFile(eng, filePath, path, { noEmbed, sourceId: opts.sourceId });
         if (result.status === 'imported') {
           chunksCreated += result.chunks;
           pagesAffected.push(result.slug);
@@ -835,7 +835,7 @@ async function performFullSync(
   const importArgs = [repoPath];
   if (opts.noEmbed) importArgs.push('--no-embed');
   if (fullConcurrency > 1) importArgs.push('--workers', String(fullConcurrency));
-  const result = await runImport(engine, importArgs, { commit: headCommit });
+  const result = await runImport(engine, importArgs, { commit: headCommit, sourceId: opts.sourceId });
 
   // Bug 9 — gate the full-sync bookmark on success. runImport already
   // writes its own sync.last_commit conditionally (import.ts), but
@@ -942,6 +942,10 @@ export async function runSync(engine: BrainEngine, args: string[]) {
   if (explicitSource || process.env.GBRAIN_SOURCE) {
     const { resolveSourceId } = await import('../core/source-resolver.ts');
     sourceId = await resolveSourceId(engine, explicitSource);
+  }
+
+  if (skipFailed && !retryFailed && !dryRun) {
+    acknowledgeExistingSyncFailuresForSkip();
   }
 
   // v0.19.0 — `sync --all` iterates all registered sources with a
@@ -1250,5 +1254,15 @@ function printSyncResult(result: SyncResult) {
       console.log(`  See ~/.gbrain/sync-failures.jsonl for details, or run 'gbrain doctor'.`);
       console.log(`  Fix the files then re-run 'gbrain sync', or 'gbrain sync --skip-failed' to move on.`);
       break;
+  }
+}
+
+function acknowledgeExistingSyncFailuresForSkip() {
+  const acked = acknowledgeSyncFailures();
+  if (acked.count > 0) {
+    console.error(
+      `  Acknowledged ${acked.count} previously-recorded failure(s):\n` +
+        `${formatCodeBreakdown(acked.summary)}`,
+    );
   }
 }

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -136,7 +136,7 @@ export interface BrainEngine {
    * by `restore_page` flow, and by operator diagnostics.
    */
   getPage(slug: string, opts?: GetPageOpts): Promise<Page | null>;
-  putPage(slug: string, page: PageInput): Promise<Page>;
+  putPage(slug: string, page: PageInput, opts?: { sourceId?: string }): Promise<Page>;
   /**
    * Hard-delete a page row. Cascades to content_chunks, page_links,
    * chunk_relations via existing FK ON DELETE CASCADE.
@@ -185,8 +185,8 @@ export interface BrainEngine {
   getEmbeddingsByChunkIds(ids: number[]): Promise<Map<number, Float32Array>>;
 
   // Chunks
-  upsertChunks(slug: string, chunks: ChunkInput[]): Promise<void>;
-  getChunks(slug: string): Promise<Chunk[]>;
+  upsertChunks(slug: string, chunks: ChunkInput[], opts?: { sourceId?: string }): Promise<void>;
+  getChunks(slug: string, opts?: { sourceId?: string }): Promise<Chunk[]>;
   /**
    * Count chunks across the entire brain where embedded_at IS NULL.
    * Pre-flight short-circuit for `embed --stale` so a 100%-embedded brain
@@ -202,7 +202,7 @@ export interface BrainEngine {
    * Bounded by an internal LIMIT of 100000 to mirror listPages.
    */
   listStaleChunks(): Promise<StaleChunkRow[]>;
-  deleteChunks(slug: string): Promise<void>;
+  deleteChunks(slug: string, opts?: { sourceId?: string }): Promise<void>;
 
   // Links
   /**
@@ -283,9 +283,9 @@ export interface BrainEngine {
   findOrphanPages(): Promise<Array<{ slug: string; title: string; domain: string | null }>>;
 
   // Tags
-  addTag(slug: string, tag: string): Promise<void>;
-  removeTag(slug: string, tag: string): Promise<void>;
-  getTags(slug: string): Promise<string[]>;
+  addTag(slug: string, tag: string, opts?: { sourceId?: string }): Promise<void>;
+  removeTag(slug: string, tag: string, opts?: { sourceId?: string }): Promise<void>;
+  getTags(slug: string, opts?: { sourceId?: string }): Promise<string[]>;
 
   // Timeline
   /**
@@ -319,7 +319,7 @@ export interface BrainEngine {
   putDreamVerdict(filePath: string, contentHash: string, verdict: DreamVerdictInput): Promise<void>;
 
   // Versions
-  createVersion(slug: string): Promise<PageVersion>;
+  createVersion(slug: string, opts?: { sourceId?: string }): Promise<PageVersion>;
   getVersions(slug: string): Promise<PageVersion[]>;
   revertToVersion(slug: string, versionId: number): Promise<void>;
 

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -173,6 +173,13 @@ export interface ImportMediaEvidenceOptions {
   rawDataSource?: string;
 }
 
+interface ImportOptions {
+  noEmbed?: boolean;
+  inferFrontmatter?: boolean;
+  force?: boolean;
+  sourceId?: string;
+}
+
 const MAX_FILE_SIZE = 5_000_000; // 5MB
 
 /**
@@ -191,7 +198,7 @@ export async function importFromContent(
   engine: BrainEngine,
   slug: string,
   content: string,
-  opts: { noEmbed?: boolean } = {},
+  opts: ImportOptions = {},
 ): Promise<ImportResult> {
   // Reject oversized payloads before any parsing, chunking, or embedding happens.
   // Uses Buffer.byteLength to count UTF-8 bytes the same way disk size would,
@@ -229,7 +236,8 @@ export async function importFromContent(
     tags: parsed.tags,
   };
 
-  const existing = await engine.getPage(slug);
+  const sourceOpts = opts.sourceId ? { sourceId: opts.sourceId } : undefined;
+  const existing = await engine.getPage(slug, sourceOpts);
   if (existing?.content_hash === hash) {
     return { slug, status: 'skipped', chunks: 0, parsedPage };
   }
@@ -272,7 +280,7 @@ export async function importFromContent(
 
   // Transaction wraps all DB writes
   await engine.transaction(async (tx) => {
-    if (existing) await tx.createVersion(slug);
+    if (existing) await tx.createVersion(slug, sourceOpts);
 
     await tx.putPage(slug, {
       type: parsed.type,
@@ -281,23 +289,24 @@ export async function importFromContent(
       timeline: parsed.timeline || '',
       frontmatter: parsed.frontmatter,
       content_hash: hash,
-    });
+      source_id: opts.sourceId,
+    }, sourceOpts);
 
     // Tag reconciliation: remove stale, add current
-    const existingTags = await tx.getTags(slug);
+    const existingTags = await tx.getTags(slug, sourceOpts);
     const newTags = new Set(parsed.tags);
     for (const old of existingTags) {
-      if (!newTags.has(old)) await tx.removeTag(slug, old);
+      if (!newTags.has(old)) await tx.removeTag(slug, old, sourceOpts);
     }
     for (const tag of parsed.tags) {
-      await tx.addTag(slug, tag);
+      await tx.addTag(slug, tag, sourceOpts);
     }
 
     if (chunks.length > 0) {
-      await tx.upsertChunks(slug, chunks);
+      await tx.upsertChunks(slug, chunks, sourceOpts);
     } else {
       // Content is empty — delete stale chunks so they don't ghost in search results
-      await tx.deleteChunks(slug);
+      await tx.deleteChunks(slug, sourceOpts);
     }
 
     // v0.19.0 E1 — doc↔impl linking: if this markdown page cites code paths
@@ -344,7 +353,7 @@ export async function importFromFile(
   engine: BrainEngine,
   filePath: string,
   relativePath: string,
-  opts: { noEmbed?: boolean; inferFrontmatter?: boolean } = {},
+  opts: ImportOptions = {},
 ): Promise<ImportResult> {
   // Defense-in-depth: reject symlinks before reading content.
   const lstat = lstatSync(filePath);
@@ -423,7 +432,7 @@ export async function importCodeFile(
   engine: BrainEngine,
   relativePath: string,
   content: string,
-  opts: { noEmbed?: boolean; force?: boolean } = {},
+  opts: ImportOptions = {},
 ): Promise<ImportResult> {
   const slug = slugifyCodePath(relativePath);
   const lang = detectCodeLanguage(relativePath) || 'unknown';
@@ -440,7 +449,8 @@ export async function importCodeFile(
     .update(JSON.stringify({ title, type: 'code', content, lang, chunker_version: CHUNKER_VERSION }))
     .digest('hex');
 
-  const existing = await engine.getPage(slug);
+  const sourceOpts = opts.sourceId ? { sourceId: opts.sourceId } : undefined;
+  const existing = await engine.getPage(slug, sourceOpts);
   if (!opts.force && existing?.content_hash === hash) {
     return { slug, status: 'skipped', chunks: 0 };
   }
@@ -478,7 +488,7 @@ export async function importCodeFile(
   // OpenAI API. Order matters: our chunk_index is semantic (tree-sitter
   // order), so a matching (chunk_index, text_hash) means a verbatim
   // preserved symbol.
-  const existingChunks = existing ? await engine.getChunks(slug) : [];
+  const existingChunks = existing ? await engine.getChunks(slug, sourceOpts) : [];
   const existingByKey = new Map<string, typeof existingChunks[number]>();
   for (const ec of existingChunks) {
     existingByKey.set(`${ec.chunk_index}:${ec.chunk_text}`, ec);
@@ -509,7 +519,7 @@ export async function importCodeFile(
 
   // Store
   await engine.transaction(async (tx) => {
-    if (existing) await tx.createVersion(slug);
+    if (existing) await tx.createVersion(slug, sourceOpts);
 
     await tx.putPage(slug, {
       type: 'code' as PageType,
@@ -519,15 +529,16 @@ export async function importCodeFile(
       timeline: '',
       frontmatter: { language: lang, file: relativePath },
       content_hash: hash,
-    });
+      source_id: opts.sourceId,
+    }, sourceOpts);
 
-    await tx.addTag(slug, 'code');
-    await tx.addTag(slug, lang);
+    await tx.addTag(slug, 'code', sourceOpts);
+    await tx.addTag(slug, lang, sourceOpts);
 
     if (chunks.length > 0) {
-      await tx.upsertChunks(slug, chunks);
+      await tx.upsertChunks(slug, chunks, sourceOpts);
     } else {
-      await tx.deleteChunks(slug);
+      await tx.deleteChunks(slug, sourceOpts);
     }
   });
 
@@ -538,7 +549,7 @@ export async function importCodeFile(
   // chunk IDs are stable.
   if (extractedEdges.length > 0 && chunks.length > 0) {
     try {
-      const persistedChunks = await engine.getChunks(slug);
+      const persistedChunks = await engine.getChunks(slug, sourceOpts);
       const byIndex = new Map<number, { id?: number; symbol_name_qualified?: string | null; start_line?: number | null; end_line?: number | null }>();
       for (const pc of persistedChunks) {
         byIndex.set(pc.chunk_index, pc);

--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -217,13 +217,15 @@ function collectValidationErrors(
   }
 
   // 5. NESTED_QUOTES — common breakage pattern: `title: "Name "Nick" Last"`.
-  //    Detect any frontmatter `key: ...` line whose value contains 3 or more
-  //    unescaped double-quote characters. A clean quoted value has 2.
+  //    Only double-quoted scalars are risky here. Unquoted YAML values can
+  //    legally contain multiple quote characters, e.g. descriptions that list
+  //    trigger phrases.
   for (let i = firstNonEmpty + 1; i < closeLine; i++) {
     const line = lines[i];
     const m = line.match(/^\s*[A-Za-z_][\w-]*\s*:\s*(.*)$/);
     if (!m) continue;
-    const value = m[1];
+    const value = m[1].trim();
+    if (!value.startsWith('"')) continue;
     let count = 0;
     for (let j = 0; j < value.length; j++) {
       if (value[j] === '"' && (j === 0 || value[j - 1] !== '\\')) count++;

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -372,10 +372,11 @@ export class PGLiteEngine implements BrainEngine {
     return rowToPage(rows[0] as Record<string, unknown>);
   }
 
-  async putPage(slug: string, page: PageInput): Promise<Page> {
+  async putPage(slug: string, page: PageInput, opts?: { sourceId?: string }): Promise<Page> {
     slug = validateSlug(slug);
     const hash = page.content_hash || contentHash(page);
     const frontmatter = page.frontmatter || {};
+    const sourceId = opts?.sourceId ?? page.source_id ?? 'default';
 
     // v0.18.0 Step 2: source_id relies on the schema DEFAULT 'default' so
     // existing callers still target the default source without threading
@@ -384,8 +385,8 @@ export class PGLiteEngine implements BrainEngine {
     // surface an explicit sourceId param on putPage for multi-source sync.
     const pageKind = page.page_kind || 'markdown';
     const { rows } = await this.db.query(
-      `INSERT INTO pages (slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, updated_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, now())
+      `INSERT INTO pages (source_id, slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, now())
        ON CONFLICT (source_id, slug) DO UPDATE SET
          type = EXCLUDED.type,
          page_kind = EXCLUDED.page_kind,
@@ -396,7 +397,7 @@ export class PGLiteEngine implements BrainEngine {
          content_hash = EXCLUDED.content_hash,
          updated_at = now()
        RETURNING id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash, created_at, updated_at`,
-      [slug, page.type, pageKind, page.title, page.compiled_truth, page.timeline || '', JSON.stringify(frontmatter), hash]
+      [sourceId, slug, page.type, pageKind, page.title, page.compiled_truth, page.timeline || '', JSON.stringify(frontmatter), hash]
     );
     return rowToPage(rows[0] as Record<string, unknown>);
   }
@@ -746,9 +747,9 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   // Chunks
-  async upsertChunks(slug: string, chunks: ChunkInput[]): Promise<void> {
+  async upsertChunks(slug: string, chunks: ChunkInput[], opts?: { sourceId?: string }): Promise<void> {
     // Get page_id
-    const pageResult = await this.db.query('SELECT id FROM pages WHERE slug = $1', [slug]);
+    const pageResult = await this.db.query('SELECT id FROM pages WHERE slug = $1 AND source_id = $2', [slug, opts?.sourceId ?? 'default']);
     if (pageResult.rows.length === 0) throw new Error(`Page not found: ${slug}`);
     const pageId = (pageResult.rows[0] as { id: number }).id;
 
@@ -833,13 +834,13 @@ export class PGLiteEngine implements BrainEngine {
     );
   }
 
-  async getChunks(slug: string): Promise<Chunk[]> {
+  async getChunks(slug: string, opts?: { sourceId?: string }): Promise<Chunk[]> {
     const { rows } = await this.db.query(
       `SELECT cc.* FROM content_chunks cc
        JOIN pages p ON p.id = cc.page_id
-       WHERE p.slug = $1
+       WHERE p.slug = $1 AND p.source_id = $2
        ORDER BY cc.chunk_index`,
-      [slug]
+      [slug, opts?.sourceId ?? 'default']
     );
     return (rows as Record<string, unknown>[]).map(r => rowToChunk(r));
   }
@@ -867,11 +868,11 @@ export class PGLiteEngine implements BrainEngine {
     return rows as unknown as StaleChunkRow[];
   }
 
-  async deleteChunks(slug: string): Promise<void> {
+  async deleteChunks(slug: string, opts?: { sourceId?: string }): Promise<void> {
     await this.db.query(
       `DELETE FROM content_chunks
-       WHERE page_id = (SELECT id FROM pages WHERE slug = $1)`,
-      [slug]
+       WHERE page_id = (SELECT id FROM pages WHERE slug = $1 AND source_id = $2)`,
+      [slug, opts?.sourceId ?? 'default']
     );
   }
 
@@ -1212,30 +1213,30 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   // Tags
-  async addTag(slug: string, tag: string): Promise<void> {
+  async addTag(slug: string, tag: string, opts?: { sourceId?: string }): Promise<void> {
     await this.db.query(
       `INSERT INTO tags (page_id, tag)
-       SELECT id, $2 FROM pages WHERE slug = $1
+       SELECT id, $2 FROM pages WHERE slug = $1 AND source_id = $3
        ON CONFLICT (page_id, tag) DO NOTHING`,
-      [slug, tag]
+      [slug, tag, opts?.sourceId ?? 'default']
     );
   }
 
-  async removeTag(slug: string, tag: string): Promise<void> {
+  async removeTag(slug: string, tag: string, opts?: { sourceId?: string }): Promise<void> {
     await this.db.query(
       `DELETE FROM tags
-       WHERE page_id = (SELECT id FROM pages WHERE slug = $1)
+       WHERE page_id = (SELECT id FROM pages WHERE slug = $1 AND source_id = $3)
          AND tag = $2`,
-      [slug, tag]
+      [slug, tag, opts?.sourceId ?? 'default']
     );
   }
 
-  async getTags(slug: string): Promise<string[]> {
+  async getTags(slug: string, opts?: { sourceId?: string }): Promise<string[]> {
     const { rows } = await this.db.query(
       `SELECT tag FROM tags
-       WHERE page_id = (SELECT id FROM pages WHERE slug = $1)
+       WHERE page_id = (SELECT id FROM pages WHERE slug = $1 AND source_id = $2)
        ORDER BY tag`,
-      [slug]
+      [slug, opts?.sourceId ?? 'default']
     );
     return (rows as { tag: string }[]).map(r => r.tag);
   }
@@ -1384,13 +1385,13 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   // Versions
-  async createVersion(slug: string): Promise<PageVersion> {
+  async createVersion(slug: string, opts?: { sourceId?: string }): Promise<PageVersion> {
     const { rows } = await this.db.query(
       `INSERT INTO page_versions (page_id, compiled_truth, frontmatter)
        SELECT id, compiled_truth, frontmatter
-       FROM pages WHERE slug = $1
+       FROM pages WHERE slug = $1 AND source_id = $2
        RETURNING *`,
-      [slug]
+      [slug, opts?.sourceId ?? 'default']
     );
     return rows[0] as unknown as PageVersion;
   }
@@ -1479,6 +1480,7 @@ export class PGLiteEngine implements BrainEngine {
         (SELECT count(*) FROM content_chunks WHERE embedded_at IS NULL) as missing_embeddings,
         (SELECT count(*) FROM links) as link_count,
         (SELECT count(DISTINCT page_id) FROM timeline_entries) as pages_with_timeline,
+        (SELECT count(*) FROM entity_pages) as entity_page_count,
         (SELECT count(*) FROM entity_pages e
          WHERE EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = e.id))::float /
           GREATEST((SELECT count(*) FROM entity_pages), 1)::float as link_coverage,
@@ -1504,6 +1506,7 @@ export class PGLiteEngine implements BrainEngine {
     const deadLinks = Number(r.dead_links);
     const linkCount = Number(r.link_count);
     const pagesWithTimeline = Number(r.pages_with_timeline);
+    const entityPageCount = Number(r.entity_page_count);
 
     const linkDensity = pageCount > 0 ? Math.min(linkCount / pageCount, 1) : 0;
     const timelineCoverageDensity = pageCount > 0 ? Math.min(pagesWithTimeline / pageCount, 1) : 0;
@@ -1526,8 +1529,9 @@ export class PGLiteEngine implements BrainEngine {
       missing_embeddings: Number(r.missing_embeddings),
       brain_score: brainScore,
       dead_links: deadLinks,
-      link_coverage: Number(r.link_coverage),
-      timeline_coverage: Number(r.timeline_coverage),
+      link_coverage: entityPageCount === 0 ? 1 : Number(r.link_coverage),
+      timeline_coverage: entityPageCount === 0 ? 1 : Number(r.timeline_coverage),
+      entity_page_count: entityPageCount,
       most_connected: (connected as { slug: string; link_count: number }[]).map(c => ({
         slug: c.slug,
         link_count: Number(c.link_count),

--- a/src/core/pglite-schema.ts
+++ b/src/core/pglite-schema.ts
@@ -1,3 +1,5 @@
+import { applyChunkEmbeddingIndexPolicy } from './vector-index.ts';
+
 /**
  * PGLite schema — derived from schema-embedded.ts (Postgres schema).
  *
@@ -530,7 +532,7 @@ export function getPGLiteSchema(dims: number = 1536, model: string = 'text-embed
     throw new Error(`Invalid embedding dimensions: ${dims}`);
   }
   const sanitizedModel = String(model).replace(/'/g, "''");
-  return PGLITE_SCHEMA_SQL_TEMPLATE
+  return applyChunkEmbeddingIndexPolicy(PGLITE_SCHEMA_SQL_TEMPLATE, parsedDims)
     .replace(/__EMBEDDING_DIMS__/g, String(parsedDims))
     .replace(/__EMBEDDING_MODEL__/g, sanitizedModel);
 }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -4,6 +4,7 @@ import { MAX_SEARCH_LIMIT, clampSearchLimit } from './engine.ts';
 import { runMigrations } from './migrate.ts';
 import { SCHEMA_SQL } from './schema-embedded.ts';
 import { verifySchema } from './schema-verify.ts';
+import { applyChunkEmbeddingIndexPolicy } from './vector-index.ts';
 import type {
   Page, PageInput, PageFilters, PageType,
   Chunk, ChunkInput, StaleChunkRow,
@@ -110,7 +111,7 @@ export class PostgresEngine implements BrainEngine {
       model = gw.getEmbeddingModel().split(':').slice(1).join(':') || model;
     } catch { /* gateway not yet configured — use defaults */ }
 
-    const sql = SCHEMA_SQL
+    const sql = applyChunkEmbeddingIndexPolicy(SCHEMA_SQL, dims)
       .replace(/vector\(1536\)/g, `vector(${dims})`)
       .replace(/'text-embedding-3-large'/g, `'${model}'`);
 
@@ -324,11 +325,12 @@ export class PostgresEngine implements BrainEngine {
     return rowToPage(rows[0]);
   }
 
-  async putPage(slug: string, page: PageInput): Promise<Page> {
+  async putPage(slug: string, page: PageInput, opts?: { sourceId?: string }): Promise<Page> {
     slug = validateSlug(slug);
     const sql = this.sql;
     const hash = page.content_hash || contentHash(page);
     const frontmatter = page.frontmatter || {};
+    const sourceId = opts?.sourceId ?? page.source_id ?? 'default';
 
     // v0.18.0 Step 2: source_id relies on schema DEFAULT 'default'. ON
     // CONFLICT target becomes (source_id, slug) since global UNIQUE(slug)
@@ -336,8 +338,8 @@ export class PostgresEngine implements BrainEngine {
     // notes; multi-source sync (Step 5) will surface an explicit sourceId.
     const pageKind = page.page_kind || 'markdown';
     const rows = await sql`
-      INSERT INTO pages (slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, updated_at)
-      VALUES (${slug}, ${page.type}, ${pageKind}, ${page.title}, ${page.compiled_truth}, ${page.timeline || ''}, ${sql.json(frontmatter as Parameters<typeof sql.json>[0])}, ${hash}, now())
+      INSERT INTO pages (source_id, slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, updated_at)
+      VALUES (${sourceId}, ${slug}, ${page.type}, ${pageKind}, ${page.title}, ${page.compiled_truth}, ${page.timeline || ''}, ${sql.json(frontmatter as Parameters<typeof sql.json>[0])}, ${hash}, now())
       ON CONFLICT (source_id, slug) DO UPDATE SET
         type = EXCLUDED.type,
         page_kind = EXCLUDED.page_kind,
@@ -780,11 +782,12 @@ export class PostgresEngine implements BrainEngine {
   }
 
   // Chunks
-  async upsertChunks(slug: string, chunks: ChunkInput[]): Promise<void> {
+  async upsertChunks(slug: string, chunks: ChunkInput[], opts?: { sourceId?: string }): Promise<void> {
     const sql = this.sql;
+    const sourceId = opts?.sourceId ?? 'default';
 
     // Get page_id
-    const pages = await sql`SELECT id FROM pages WHERE slug = ${slug}`;
+    const pages = await sql`SELECT id FROM pages WHERE slug = ${slug} AND source_id = ${sourceId}`;
     if (pages.length === 0) throw new Error(`Page not found: ${slug}`);
     const pageId = pages[0].id;
 
@@ -869,12 +872,13 @@ export class PostgresEngine implements BrainEngine {
     );
   }
 
-  async getChunks(slug: string): Promise<Chunk[]> {
+  async getChunks(slug: string, opts?: { sourceId?: string }): Promise<Chunk[]> {
     const sql = this.sql;
+    const sourceId = opts?.sourceId ?? 'default';
     const rows = await sql`
       SELECT cc.* FROM content_chunks cc
       JOIN pages p ON p.id = cc.page_id
-      WHERE p.slug = ${slug}
+      WHERE p.slug = ${slug} AND p.source_id = ${sourceId}
       ORDER BY cc.chunk_index
     `;
     return rows.map((r) => rowToChunk(r as Record<string, unknown>));
@@ -904,11 +908,12 @@ export class PostgresEngine implements BrainEngine {
     return rows as unknown as StaleChunkRow[];
   }
 
-  async deleteChunks(slug: string): Promise<void> {
+  async deleteChunks(slug: string, opts?: { sourceId?: string }): Promise<void> {
     const sql = this.sql;
+    const sourceId = opts?.sourceId ?? 'default';
     await sql`
       DELETE FROM content_chunks
-      WHERE page_id = (SELECT id FROM pages WHERE slug = ${slug})
+      WHERE page_id = (SELECT id FROM pages WHERE slug = ${slug} AND source_id = ${sourceId})
     `;
   }
 
@@ -1265,11 +1270,12 @@ export class PostgresEngine implements BrainEngine {
   }
 
   // Tags
-  async addTag(slug: string, tag: string): Promise<void> {
+  async addTag(slug: string, tag: string, opts?: { sourceId?: string }): Promise<void> {
     const sql = this.sql;
+    const sourceId = opts?.sourceId ?? 'default';
     // Verify page exists before attempting insert (ON CONFLICT DO NOTHING
     // swallows the "already tagged" case, but we still need to detect missing pages)
-    const page = await sql`SELECT id FROM pages WHERE slug = ${slug}`;
+    const page = await sql`SELECT id FROM pages WHERE slug = ${slug} AND source_id = ${sourceId}`;
     if (page.length === 0) throw new Error(`addTag failed: page "${slug}" not found`);
     await sql`
       INSERT INTO tags (page_id, tag)
@@ -1278,20 +1284,22 @@ export class PostgresEngine implements BrainEngine {
     `;
   }
 
-  async removeTag(slug: string, tag: string): Promise<void> {
+  async removeTag(slug: string, tag: string, opts?: { sourceId?: string }): Promise<void> {
     const sql = this.sql;
+    const sourceId = opts?.sourceId ?? 'default';
     await sql`
       DELETE FROM tags
-      WHERE page_id = (SELECT id FROM pages WHERE slug = ${slug})
+      WHERE page_id = (SELECT id FROM pages WHERE slug = ${slug} AND source_id = ${sourceId})
         AND tag = ${tag}
     `;
   }
 
-  async getTags(slug: string): Promise<string[]> {
+  async getTags(slug: string, opts?: { sourceId?: string }): Promise<string[]> {
     const sql = this.sql;
+    const sourceId = opts?.sourceId ?? 'default';
     const rows = await sql`
       SELECT tag FROM tags
-      WHERE page_id = (SELECT id FROM pages WHERE slug = ${slug})
+      WHERE page_id = (SELECT id FROM pages WHERE slug = ${slug} AND source_id = ${sourceId})
       ORDER BY tag
     `;
     return rows.map((r) => r.tag as string);
@@ -1441,12 +1449,13 @@ export class PostgresEngine implements BrainEngine {
   }
 
   // Versions
-  async createVersion(slug: string): Promise<PageVersion> {
+  async createVersion(slug: string, opts?: { sourceId?: string }): Promise<PageVersion> {
     const sql = this.sql;
+    const sourceId = opts?.sourceId ?? 'default';
     const rows = await sql`
       INSERT INTO page_versions (page_id, compiled_truth, frontmatter)
       SELECT id, compiled_truth, frontmatter
-      FROM pages WHERE slug = ${slug}
+      FROM pages WHERE slug = ${slug} AND source_id = ${sourceId}
       RETURNING *
     `;
     if (rows.length === 0) throw new Error(`createVersion failed: page "${slug}" not found`);
@@ -1545,6 +1554,7 @@ export class PostgresEngine implements BrainEngine {
         (SELECT count(*) FROM content_chunks WHERE embedded_at IS NULL) as missing_embeddings,
         (SELECT count(*) FROM links) as link_count,
         (SELECT count(DISTINCT page_id) FROM timeline_entries) as pages_with_timeline,
+        (SELECT count(*) FROM entity_pages) as entity_page_count,
         (SELECT count(*) FROM entity_pages e
          WHERE EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = e.id))::float /
           GREATEST((SELECT count(*) FROM entity_pages), 1)::float as link_coverage,
@@ -1568,6 +1578,7 @@ export class PostgresEngine implements BrainEngine {
     const deadLinks = Number(h.dead_links);
     const linkCount = Number(h.link_count);
     const pagesWithTimeline = Number(h.pages_with_timeline);
+    const entityPageCount = Number(h.entity_page_count);
 
     // brain_score: 0-100 weighted average
     const linkDensity = pageCount > 0 ? Math.min(linkCount / pageCount, 1) : 0;
@@ -1590,8 +1601,9 @@ export class PostgresEngine implements BrainEngine {
       missing_embeddings: Number(h.missing_embeddings),
       brain_score: brainScore,
       dead_links: deadLinks,
-      link_coverage: Number(h.link_coverage),
-      timeline_coverage: Number(h.timeline_coverage),
+      link_coverage: entityPageCount === 0 ? 1 : Number(h.link_coverage),
+      timeline_coverage: entityPageCount === 0 ? 1 : Number(h.timeline_coverage),
+      entity_page_count: entityPageCount,
       most_connected: (connected as unknown as { slug: string; link_count: number }[]).map(c => ({
         slug: c.slug,
         link_count: Number(c.link_count),

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -185,8 +185,10 @@ export function isSyncable(path: string, opts: SyncableOptions = {}): boolean {
 
   if (!isAllowedByStrategy(path, strategy)) return false;
 
-  // Skip hidden directories
-  if (path.split('/').some(p => p.startsWith('.'))) return false;
+  const segments = path.split('/');
+
+  // Skip hidden directories and dependency/vendor caches.
+  if (segments.some(p => p.startsWith('.') || p === 'node_modules')) return false;
 
   // Skip .raw/ sidecar directories
   if (path.includes('.raw/')) return false;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -42,6 +42,8 @@ export interface PageInput {
    * `query --lang` filtering.
    */
   page_kind?: PageKind;
+  /** Target source for multi-source imports. Defaults to 'default'. */
+  source_id?: string;
 }
 
 export interface PageFilters {
@@ -377,6 +379,8 @@ export interface BrainHealth {
   link_coverage: number;
   /** Fraction of entity pages (person/company) with >= 1 structured timeline entry. */
   timeline_coverage: number;
+  /** Number of entity pages included in link_coverage/timeline_coverage. */
+  entity_page_count?: number;
   /** Top 5 entities by total link count (in + out). */
   most_connected: Array<{ slug: string; link_count: number }>;
   /**

--- a/src/core/vector-index.ts
+++ b/src/core/vector-index.ts
@@ -1,0 +1,16 @@
+export const PGVECTOR_HNSW_VECTOR_MAX_DIMS = 2000;
+
+const CHUNK_EMBEDDING_HNSW_INDEX =
+  'CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON content_chunks USING hnsw (embedding vector_cosine_ops);';
+
+export function chunkEmbeddingIndexSql(dims: number): string {
+  if (dims <= PGVECTOR_HNSW_VECTOR_MAX_DIMS) return CHUNK_EMBEDDING_HNSW_INDEX;
+  return [
+    '-- idx_chunks_embedding skipped: pgvector hnsw vector indexes support',
+    `-- at most ${PGVECTOR_HNSW_VECTOR_MAX_DIMS} dimensions; exact vector scans remain available.`,
+  ].join('\n');
+}
+
+export function applyChunkEmbeddingIndexPolicy(sql: string, dims: number): string {
+  return sql.replaceAll(CHUNK_EMBEDDING_HNSW_INDEX, chunkEmbeddingIndexSql(dims));
+}

--- a/test/ai/schema-templating.test.ts
+++ b/test/ai/schema-templating.test.ts
@@ -25,6 +25,16 @@ describe('getPGLiteSchema', () => {
     expect(sql).toMatch(/'voyage-3-large'/);
     expect(sql).toMatch(/\('embedding_model', 'voyage-3-large'\)/);
     expect(sql).toMatch(/\('embedding_dimensions', '1024'\)/);
+    expect(sql).toContain('USING hnsw');
+  });
+
+  test('Voyage 2048d skips unsupported HNSW index but keeps vector column', () => {
+    const sql = getPGLiteSchema(2048, 'voyage-4-large');
+    expect(sql).toMatch(/vector\(2048\)/);
+    expect(sql).toMatch(/'voyage-4-large'/);
+    expect(sql).toMatch(/\('embedding_dimensions', '2048'\)/);
+    expect(sql).not.toContain('idx_chunks_embedding ON content_chunks USING hnsw');
+    expect(sql).toContain('exact vector scans remain available');
   });
 
   test('PGLITE_SCHEMA_SQL back-compat constant is the default-dim schema', () => {

--- a/test/integrity.test.ts
+++ b/test/integrity.test.ts
@@ -81,6 +81,11 @@ describe('findBareTweetHits', () => {
     expect(hits).toEqual([]);
   });
 
+  test('does NOT trigger on technical X API descriptions', () => {
+    const hits = findBareTweetHits('Fetch List details via X API v2.', 'docs/x-api');
+    expect(hits).toEqual([]);
+  });
+
   test('only one hit per line even if multiple phrases match', () => {
     const hits = findBareTweetHits('He tweeted about it in a tweet later.', 'people/x');
     expect(hits).toHaveLength(1);

--- a/test/markdown-validation.test.ts
+++ b/test/markdown-validation.test.ts
@@ -133,6 +133,12 @@ describe('parseMarkdown validation surface', () => {
       const parsed = parseMarkdown(md, undefined, { validate: true });
       expect(parsed.errors!.map(e => e.code)).not.toContain('NESTED_QUOTES');
     });
+
+    test('unquoted description with trigger phrases does not trigger', () => {
+      const md = `${fence}\ntype: skill\ndescription: Use when phrases like "provider config", "which models", and "base URL" appear.\n${fence}\n\nbody`;
+      const parsed = parseMarkdown(md, undefined, { validate: true });
+      expect(parsed.errors!.map(e => e.code)).not.toContain('NESTED_QUOTES');
+    });
   });
 
   describe('EMPTY_FRONTMATTER', () => {

--- a/test/multi-source-integration.test.ts
+++ b/test/multi-source-integration.test.ts
@@ -17,9 +17,14 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { runImport } from '../src/commands/import.ts';
 import { runSources } from '../src/commands/sources.ts';
 import { resolveSourceId } from '../src/core/source-resolver.ts';
+import { importFromContent } from '../src/core/import-file.ts';
 
 let engine: PGLiteEngine;
 
@@ -75,6 +80,73 @@ describe('v0.18.0 — putPage implicitly writes to default source', () => {
     expect(rows.length).toBe(1);
     expect(rows[0].source_id).toBe('default');
   });
+
+  test('putPage with explicit source writes outside default', async () => {
+    await runSources(engine, ['add', 'putsrc', '--no-federated']);
+    await engine.putPage('topics/source-aware-put', {
+      type: 'concept',
+      title: 'Source Aware Put',
+      compiled_truth: 'Written under a named source.',
+    }, { sourceId: 'putsrc' });
+
+    const rows = await engine.executeRaw<{ source_id: string; slug: string }>(
+      `SELECT source_id, slug FROM pages WHERE slug = 'topics/source-aware-put'`,
+    );
+    expect(rows).toEqual([{ source_id: 'putsrc', slug: 'topics/source-aware-put' }]);
+  });
+
+  test('importFromContent threads sourceId through page, tags, and chunks', async () => {
+    await runSources(engine, ['add', 'importsrc', '--no-federated']);
+    const md = [
+      '---',
+      'title: Source Import',
+      'type: concept',
+      'tags: [source-aware]',
+      '---',
+      '',
+      '# Source Import',
+      '',
+      'This page should live outside the default source.',
+    ].join('\n');
+
+    const result = await importFromContent(engine, 'topics/source-import', md, { sourceId: 'importsrc', noEmbed: true });
+    expect(result.status).toBe('imported');
+
+    const pages = await engine.executeRaw<{ source_id: string }>(
+      `SELECT source_id FROM pages WHERE slug = 'topics/source-import'`,
+    );
+    expect(pages).toEqual([{ source_id: 'importsrc' }]);
+
+    expect(await engine.getTags('topics/source-import', { sourceId: 'importsrc' })).toContain('source-aware');
+    expect(await engine.getChunks('topics/source-import', { sourceId: 'importsrc' })).toHaveLength(1);
+    expect(await engine.getPage('topics/source-import')).toBeNull();
+  });
+
+  test('runImport threads sourceId during full-directory imports', async () => {
+    await runSources(engine, ['add', 'fullimportsrc', '--no-federated']);
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-source-import-'));
+    try {
+      writeFileSync(join(dir, 'full-import.md'), [
+        '---',
+        'title: Full Import',
+        'type: concept',
+        '---',
+        '',
+        '# Full Import',
+        '',
+        'Directory import should preserve the requested source.',
+      ].join('\n'));
+
+      const result = await runImport(engine, [dir, '--no-embed', '--fresh'], { sourceId: 'fullimportsrc' });
+      expect(result.imported).toBe(1);
+      const rows = await engine.executeRaw<{ source_id: string }>(
+        `SELECT source_id FROM pages WHERE slug = 'full-import'`,
+      );
+      expect(rows).toEqual([{ source_id: 'fullimportsrc' }]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('v0.18.0 — composite UNIQUE allows same-slug across sources', () => {
@@ -83,9 +155,8 @@ describe('v0.18.0 — composite UNIQUE allows same-slug across sources', () => {
     await runSources(engine, ['add', 'testsrc', '--no-federated']);
 
     // Sanity: default already has this slug from the previous test.
-    // Now write the same slug under testsrc via raw INSERT (putPage only
-    // targets default until a later step surfaces sourceId; raw INSERT is
-    // the "source-aware write" Step 5 continuation will add).
+    // Now write the same slug under testsrc via raw INSERT to prove the
+    // composite unique allows same-slug pages across sources.
     await engine.executeRaw(
       `INSERT INTO pages (source_id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash)
        VALUES ('testsrc', 'topics/step9-auto', 'concept', 'Step 9 Auto (testsrc variant)',

--- a/test/sync-failures.test.ts
+++ b/test/sync-failures.test.ts
@@ -138,6 +138,7 @@ describe('Bug 9 — sync.ts CLI flag wiring', () => {
     expect(source).toContain("args.includes('--retry-failed')");
     expect(source).toContain('skipFailed');
     expect(source).toContain('retryFailed');
+    expect(source).toContain('acknowledgeExistingSyncFailuresForSkip');
   });
 
   test('performSync gates sync.last_commit on failedFiles.length', async () => {

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -81,6 +81,11 @@ describe('isSyncable', () => {
     expect(isSyncable('people/.hidden/secret.md')).toBe(false);
   });
 
+  test('rejects files in dependency directories', () => {
+    expect(isSyncable('node_modules/pkg/README.md')).toBe(false);
+    expect(isSyncable('tools/server/node_modules/pkg/HISTORY.md')).toBe(false);
+  });
+
   test('rejects .raw/ sidecar directories', () => {
     expect(isSyncable('people/pedro.raw/source.md')).toBe(false);
     expect(isSyncable('dir/.raw/notes.md')).toBe(false);


### PR DESCRIPTION
## Summary

- Supports fresh PGLite setup with `voyage:voyage-4-large` at 2048 dimensions by keeping `vector(2048)` storage and skipping only pgvector HNSW index creation when the dimension is above pgvector's 2000d HNSW ceiling.
- Fixes full-directory source sync/import paths so pages, tags, chunks, and versions stay attached to the requested `source_id` instead of leaking into `default`.
- Cleans up setup/doctor false positives found during the live install: dependency-folder frontmatter audits, nested quote validation on unquoted prose, PGLite-only doctor applicability, X API text in integrity checks, acknowledged skip-failed failures, and resolver routing rows.

Closes #35.
Closes #36.
Closes #37.

## Why

During the fresh Eva Brain install we needed a clean brain using Voyage 4 Large at 2048d. Init failed because the schema tried to create an HNSW index on `vector(2048)`, but pgvector HNSW supports up to 2000 dimensions. Exact vector scans still work at 2048d, so this keeps the requested embedding width and avoids only the unsupported index.

The live source sync also exposed a source-boundary bug: `sync --source` calls the full import path, but that import path did not carry the source id through all write/read helpers. That made imported pages land under `default`, which breaks the OpenClaw/company-brain install shape. The PR threads source identity through import, chunks, tags, and versions.

## Validation

- `git diff --check`
- `bun run verify`
- `bun run test` — 3841 pass, 0 fail
- Focused regression suite before full run:
  - `bun test test/ai/schema-templating.test.ts test/markdown-validation.test.ts test/sync.test.ts test/sync-failures.test.ts test/integrity.test.ts test/multi-source-integration.test.ts test/pglite-engine.test.ts` — 240 pass, 0 fail
  - `bun test test/check-resolvable.test.ts test/resolver.test.ts test/routing-eval.test.ts test/build-llms.test.ts` — 157 pass, 0 fail
- Live install smoke:
  - archived old `~/.gbrain`
  - `gbrain init --pglite --embedding-model voyage:voyage-4-large --embedding-dimensions 2048 --json`
  - `gbrain providers test` — Voyage returned 2048 dims
  - source sync produced separated sources: `eva-workspace` 1511 pages, `openclaw-support-kb` 653 pages, `default` 0 pages
  - `gbrain stats` — 2164 pages, 13446 chunks, 13446 embedded
  - `gbrain frontmatter audit --source eva-workspace --json` — clean
  - `gbrain frontmatter audit --source openclaw-support-kb --json` — clean
  - `gbrain doctor` — 95/100, all checks OK with the expected brain-score warning for no link/timeline graph yet


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded skill trigger detection with additional phrases for data research, media ingestion, book analysis, and article enrichment.
  * Import error tracking with detailed per-file failure information.
  * Multi-source page management with source-scoped operations.

* **Bug Fixes**
  * Improved sync failure handling with explicit acknowledgment before retrying with --skip-failed flag.
  * Fixed regex patterns for bare tweet and YAML validation edge cases.
  * Stricter path filtering to exclude node_modules directories during sync.

* **Improvements**
  * Vector index support extended to embeddings up to 2000 dimensions.
  * Enhanced health checks with entity page count reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->