### PR TITLE
fix: keep doctor healthy when graph score is not applicable

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -615,10 +615,16 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
         `orphans ${health.no_orphans_score}/15`,
         `dead-links ${health.no_dead_links_score}/10`,
       ];
+      const graphScoreNotApplicable =
+        (health.entity_page_count ?? 0) === 0 &&
+        health.link_density_score === 0 &&
+        health.timeline_coverage_score === 0;
       checks.push({
         name: 'brain_score',
-        status: health.brain_score >= 70 ? 'ok' : 'warn',
-        message: `Brain score ${health.brain_score}/100 (${parts.join(', ')})`,
+        status: health.brain_score >= 70 || graphScoreNotApplicable ? 'ok' : 'warn',
+        message: graphScoreNotApplicable
+          ? `Brain graph score not applicable yet (no entity/link/timeline graph exists; ${parts.join(', ')})`
+          : `Brain score ${health.brain_score}/100 (${parts.join(', ')})`,
       });
     } else {
       checks.push({ name: 'brain_score', status: 'ok', message: `Brain score 100/100` });

--- a/test/brain-score-breakdown.test.ts
+++ b/test/brain-score-breakdown.test.ts
@@ -123,6 +123,13 @@ describe('Bug 11 — doctor renders brain_score breakdown', () => {
     expect(source).toContain('no_orphans_score');
     expect(source).toContain('no_dead_links_score');
   });
+
+  test('doctor treats graph-density score as informational before a graph exists', async () => {
+    const source = await Bun.file(new URL('../src/commands/doctor.ts', import.meta.url)).text();
+    expect(source).toContain('graphScoreNotApplicable');
+    expect(source).toContain('Brain graph score not applicable yet');
+    expect(source).toContain('health.brain_score >= 70 || graphScoreNotApplicable');
+  });
 });
 
 describe('Bug 11 — BrainHealth type shape', () => {


### PR DESCRIPTION
Closes #41.

## Summary

Doctor was reporting a warning on docs/support brains that have no entity/link/timeline graph yet, even when every install/setup check was healthy.

This keeps the graph-density score visible, but treats it as informational when there is no graph surface to evaluate:

```mermaid
flowchart LR
  A[doctor] --> B[engine.getHealth]
  B --> C{entity/link/timeline graph exists?}
  C -->|yes| D[brain_score can warn below threshold]
  C -->|no| E[brain_score is informational]
  E --> F[doctor health remains healthy if all setup checks pass]
```

## Why

For Eva's current OpenClaw support/documentation brain, the corpus is searchable and fully embedded, but it does not contain internal entity graph markup. `gbrain extract all` correctly created 0 links/timeline entries. Penalizing doctor health for that made the install look unhealthy even though graph coverage already said “not applicable.”

## Validation

- `bun test test/brain-score-breakdown.test.ts test/doctor.test.ts` -> 24 pass, 0 fail
- `git diff --check`
- `bun run verify`
- Live `/Users/lume/.openclaw/extensions/gbrain/bin/gbrain doctor --json` -> `status: healthy`, `health_score: 100`, no warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced diagnostic health checks to accurately handle states where the data graph hasn't fully formed yet, ensuring appropriate status reporting and clearer messaging when context is incomplete or initializing.

* **Tests**
  * Added test coverage to verify diagnostic health check accuracy during early-stage scenarios and incomplete graph formation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->