### PR TITLE
fix: align health score with graph applicability

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -212,10 +212,14 @@ function formatResult(opName: string, result: unknown): string {
       // Health score weights: missing_embeddings is the heaviest (2 pts), other
       // graph quality issues are 1 pt each. link_coverage / timeline_coverage below
       // 50% on entity pages indicates the graph needs population.
+      const graphScoreNotApplicable =
+        (h.entity_page_count ?? 0) === 0 &&
+        h.link_density_score === 0 &&
+        h.timeline_coverage_score === 0;
       const score = Math.max(0, 10
         - (h.missing_embeddings > 0 ? 2 : 0)
         - (h.stale_pages > 0 ? 1 : 0)
-        - (h.orphan_pages > 0 ? 1 : 0)
+        - (!graphScoreNotApplicable && h.orphan_pages > 0 ? 1 : 0)
         - ((h.link_coverage ?? 1) < 0.5 ? 1 : 0)
         - ((h.timeline_coverage ?? 1) < 0.5 ? 1 : 0));
       const lines = [

--- a/test/features.test.ts
+++ b/test/features.test.ts
@@ -76,6 +76,12 @@ describe('brain_score calculation', () => {
     // embed_coverage contributes more
     expect(score).toBeGreaterThan(score2);
   });
+
+  it('health command treats orphan score as informational before a graph exists', async () => {
+    const cliSource = await Bun.file('src/cli.ts').text();
+    expect(cliSource).toContain('graphScoreNotApplicable');
+    expect(cliSource).toContain('!graphScoreNotApplicable && h.orphan_pages > 0');
+  });
 });
 
 // CLI routing


### PR DESCRIPTION
Closes #43.

## Summary

Aligns `gbrain health` with the doctor behavior merged in #42.

When a brain has no entity/link/timeline graph yet, graph-density scoring is informational. `doctor` already treats that as a healthy setup state; this keeps the older 10-point `health` command from deducting an orphan-page point for the same non-applicable graph state.

```mermaid
flowchart LR
  A[gbrain health] --> B[engine.getHealth]
  B --> C{entity/link/timeline graph exists?}
  C -->|yes| D[orphan penalty applies]
  C -->|no| E[orphan penalty skipped]
  E --> F[healthy docs brain reports 10/10]
```

## Validation

- `bun test test/features.test.ts test/brain-score-breakdown.test.ts test/doctor.test.ts` -> 34 pass, 0 fail
- `git diff --check`
- `bun run verify`
- Live `/Users/lume/.openclaw/extensions/gbrain/bin/gbrain health` -> `Health score: 10/10`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined health command output scoring to more intelligently handle orphan pages by conditionally applying penalties. The system now provides more accurate health assessments based on current operational state.

* **Tests**
  * Added test coverage validating the updated health scoring behavior and conditional penalty application logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->