### PR TITLE
Make Eva Brain one-link OpenClaw install fleet-safe

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,19 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc  # v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          version="8.30.1"
+          curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${version}/gitleaks_${version}_linux_x64.tar.gz" -o /tmp/gitleaks.tar.gz
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+      - name: Scan working tree and branch commits
+        run: |
+          set -euo pipefail
+          gitleaks dir . --redact --no-banner
+          gitleaks git . --redact --no-banner --log-opts="origin/master..HEAD"
 
   test:
     # ubuntu-latest is free 2-core/7GB. Larger runners (16-cores, etc.) require

--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -1,6 +1,7 @@
 # GBrain Installation Guide for AI Agents
 
-Read this entire file, then follow the steps. Ask the user for API keys when needed.
+Read this entire file, then follow the steps. Ask the user for `VOYAGE_API_KEY`
+only if the local environment does not already provide it.
 Target: ~30 minutes to a fully working brain.
 
 ## Step 0: If you are not Claude Code
@@ -10,14 +11,14 @@ protocol (install, read order, trust boundary, common tasks). Claude Code reads
 `CLAUDE.md` automatically and can skip ahead.
 
 If you fetched this file by URL without cloning yet, the companion files live at:
-- `https://raw.githubusercontent.com/garrytan/gbrain/master/AGENTS.md` — start here
-- `https://raw.githubusercontent.com/garrytan/gbrain/master/llms.txt` — full doc map
-- `https://raw.githubusercontent.com/garrytan/gbrain/master/llms-full.txt` — same map, inlined
+- `https://raw.githubusercontent.com/electricsheephq/eva-brain/master/AGENTS.md` — start here
+- `https://raw.githubusercontent.com/electricsheephq/eva-brain/master/llms.txt` — full doc map
+- `https://raw.githubusercontent.com/electricsheephq/eva-brain/master/llms-full.txt` — same map, inlined
 
 ## Step 1: Install GBrain
 
 ```bash
-git clone https://github.com/garrytan/gbrain.git ~/gbrain && cd ~/gbrain
+git clone https://github.com/electricsheephq/eva-brain.git ~/eva-brain && cd ~/eva-brain
 curl -fsSL https://bun.sh/install | bash
 export PATH="$HOME/.bun/bin:$PATH"
 bun install && bun link
@@ -26,46 +27,96 @@ bun install && bun link
 Verify: `gbrain --version` should print a version number. If `gbrain` is not found,
 restart the shell or add the PATH export to the shell profile.
 
-> **Do NOT use `bun install -g github:garrytan/gbrain`.** Bun blocks the top-level
+> **Do NOT use `bun install -g github:electricsheephq/eva-brain`.** Bun blocks the top-level
 > postinstall hook on global installs, so schema migrations never run and the CLI
 > aborts with `Aborted()` when it opens PGLite. Use the `git clone + bun link` path
 > above. Tracking issue: [#218](https://github.com/garrytan/gbrain/issues/218).
 
 ## Step 2: AI Provider Setup
 
-Default path:
+Default Eva/OpenClaw path:
 
 ```bash
-export OPENAI_API_KEY=sk-...
-export ANTHROPIC_API_KEY=sk-ant-...   # optional, improves search quality
+export VOYAGE_API_KEY=...
 ```
 
-Save to shell profile or `.env`.
+Save it to the shell profile or to `~/.gbrain/gbrain.env`. Voyage is for
+embeddings. OpenClaw/Codex OAuth is used by the OpenClaw plugin for extraction;
+do not ask users for an OpenAI API key just to run Eva Brain extraction.
 
 Before initializing the brain, verify the provider you plan to use:
 
 ```bash
 gbrain providers list
 gbrain providers explain
-gbrain providers test --model openai:text-embedding-3-large
+gbrain providers test --model voyage:voyage-4-large
 ```
 
 Without an embedding provider, keyword search still works but semantic/hybrid retrieval will not.
-Without Anthropic, search works but skips Anthropic-backed expansion.
 
-If you want Voyage, Google, Ollama, or LiteLLM instead of OpenAI, read:
+If you want Google, Ollama, LiteLLM, or another provider instead of Voyage, read:
 
 - `docs/guides/provider-install-matrix.md` — provider matrix, exact init commands, dimension contract, rollback notes
 - `docs/GBRAIN_VERIFY.md` — post-install verification checklist
 
-**OpenClaw Codex OAuth note:** this install guide only documents verified API-key-backed provider setup today. Durable OpenClaw-managed Codex/OpenAI OAuth wiring is tracked separately in `100yenadmin/eva-brain#2`.
+**OpenClaw Codex OAuth note:** the OpenClaw plugin exposes `/plugins/gbrain/extract`
+and routes extraction through OpenClaw's logged-in Codex runtime. The GBrain CLI
+still needs a gateway URL/token when calling that route from outside OpenClaw,
+but the extraction model auth is owned by OpenClaw, not by a user-supplied
+OpenAI API key.
 
 ## Step 3: Create the Brain
 
 ```bash
-gbrain init                           # PGLite, no server needed
+gbrain init --pglite --embedding-model voyage:voyage-4-large --embedding-dimensions 2048
 gbrain doctor --json                  # verify all checks pass
 ```
+
+## Step 3.5: Install The OpenClaw Plugin
+
+If OpenClaw is installed on this machine, install the native plugin from the
+same Eva Brain checkout:
+
+```bash
+cd ~/eva-brain
+openclaw plugins install --dangerously-force-unsafe-install ./plugins/openclaw-gbrain
+openclaw plugins enable gbrain
+openclaw gateway restart
+openclaw plugins inspect gbrain --runtime --json
+openclaw gbrain status
+```
+
+The plugin provides:
+
+- `gbrain_status`
+- `gbrain_search`
+- `gbrain_query`
+- `/plugins/gbrain/extract` for OAuth-backed extraction through OpenClaw/Codex
+
+If OpenClaw is not installed, skip this step and keep the CLI/MCP path.
+
+## Step 3.6: Install The OpenClaw Support KB
+
+For OpenClaw customer/support work, install the KB source and support skills
+after GBrain is healthy:
+
+```bash
+export OPENCLAW_SUPPORT_KB_REPO="https://github.com/electricsheephq/openclaw-support-kb.git"
+export OPENCLAW_SUPPORT_KB_DIR="$HOME/.gbrain/sources/openclaw-support-kb"
+
+if [ -d "$OPENCLAW_SUPPORT_KB_DIR/.git" ]; then
+  git -C "$OPENCLAW_SUPPORT_KB_DIR" pull --ff-only
+else
+  git clone "$OPENCLAW_SUPPORT_KB_REPO" "$OPENCLAW_SUPPORT_KB_DIR"
+fi
+
+cd "$OPENCLAW_SUPPORT_KB_DIR"
+node scripts/update-client.mjs
+node scripts/status.mjs
+```
+
+This installs the four OpenClaw support skills and registers the
+`openclaw-support-kb` GBrain source.
 
 The user's markdown files (notes, docs, brain repo) are SEPARATE from this tool repo.
 Ask the user where their files are, or create a new brain repo:
@@ -74,9 +125,9 @@ Ask the user where their files are, or create a new brain repo:
 mkdir -p ~/brain && cd ~/brain && git init
 ```
 
-Read `~/gbrain/docs/GBRAIN_RECOMMENDED_SCHEMA.md` and set up the MECE directory
+Read `~/eva-brain/docs/GBRAIN_RECOMMENDED_SCHEMA.md` and set up the MECE directory
 structure (people/, companies/, concepts/, etc.) inside the user's brain repo,
-NOT inside ~/gbrain.
+NOT inside `~/eva-brain`.
 
 ## Step 4: Import and Index
 
@@ -112,7 +163,7 @@ and supports `--since YYYY-MM-DD` for incremental runs.
 
 ## Step 5: Load Skills
 
-Read `~/gbrain/skills/RESOLVER.md`. This is the skill dispatcher. It tells you which
+Read `~/eva-brain/skills/RESOLVER.md`. This is the skill dispatcher. It tells you which
 skill to read for any task. Save this to your memory permanently.
 
 The three most important skills to adopt immediately:
@@ -153,7 +204,7 @@ Set up using your platform's scheduler (OpenClaw cron, Railway cron, crontab):
 
 ## Step 8: Integrations
 
-Run `gbrain integrations list`. Each recipe in `~/gbrain/recipes/` is a self-contained
+Run `gbrain integrations list`. Each recipe in `~/eva-brain/recipes/` is a self-contained
 installer. It tells you what credentials to ask for, how to validate, and what cron
 to register. Ask the user which integrations they want (email, calendar, voice, Twitter).
 
@@ -167,12 +218,12 @@ actually works) is the most important.
 ## Upgrade
 
 ```bash
-cd ~/gbrain && git pull origin master && bun install
+cd ~/eva-brain && git pull origin master && bun install
 gbrain init                           # apply schema migrations (idempotent)
 gbrain post-upgrade                   # show migration notes for the version range
 ```
 
-Then read `~/gbrain/skills/migrations/v<NEW_VERSION>.md` (and any intermediate
+Then read `~/eva-brain/skills/migrations/v<NEW_VERSION>.md` (and any intermediate
 versions you skipped) and run any backfill or verification steps it lists. Skipping
 this is how features ship in the binary but stay dormant in the user's brain.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ GBrain is those patterns, generalized. 34 skills. Install in 30 minutes. Your ag
 
 **New in v0.25.0 — BrainBench-Real (session capture, contributor opt-in):** with `GBRAIN_CONTRIBUTOR_MODE=1` set in your shell, every real `query` + `search` call through MCP, CLI, or the subagent tool-bridge gets captured (PII-scrubbed) into an `eval_candidates` table. Snapshot with `gbrain eval export`, replay against your code change with `gbrain eval replay`. Three numbers come back: mean Jaccard@k between captured and current retrieved slugs, top-1 stability, and latency Δ. **Off by default** for production users — no surprise data accumulation. Walkthrough: [docs/eval-bench.md](docs/eval-bench.md). NDJSON wire format: [docs/eval-capture.md](docs/eval-capture.md).
 
-> **~30 minutes to a fully working brain.** Database ready in 2 seconds (PGLite, no server). You just answer questions about API keys.
+> **~30 minutes to a fully working brain.** Database ready in 2 seconds (PGLite, no server). For Eva/OpenClaw installs, Voyage powers embeddings and OpenClaw's logged-in Codex runtime powers extraction.
 
 > **LLMs:** fetch [`llms.txt`](llms.txt) for the documentation map, or [`llms-full.txt`](llms-full.txt) for the same map with core docs inlined in one fetch. **Agents:** start with [`AGENTS.md`](AGENTS.md) (or [`CLAUDE.md`](CLAUDE.md) if you're Claude Code).
 
@@ -27,31 +27,31 @@ Paste this into your agent:
 
 ```
 Retrieve and follow the instructions at:
-https://raw.githubusercontent.com/garrytan/gbrain/master/INSTALL_FOR_AGENTS.md
+https://raw.githubusercontent.com/electricsheephq/eva-brain/master/INSTALL_FOR_AGENTS.md
 ```
 
-That's it. The agent clones the repo, installs GBrain, sets up the brain, loads 34 skills, and configures recurring jobs. You answer a few questions about API keys. ~30 minutes.
+That's it. The agent clones Eva Brain, installs GBrain, sets up a Voyage 4 Large 2048d brain when `VOYAGE_API_KEY` is available, installs the OpenClaw plugin, and verifies the local doctor score. ~30 minutes.
 
-For provider choice, embedding dimensions, Voyage 1024d migration, and the current OpenClaw Codex OAuth dependency boundary, read [`docs/guides/provider-install-matrix.md`](docs/guides/provider-install-matrix.md).
+For provider choice, embedding dimensions, Voyage 4 Large 2048d setup, and the OpenClaw Codex OAuth extraction boundary, read [`docs/guides/provider-install-matrix.md`](docs/guides/provider-install-matrix.md).
 
 If your agent doesn't auto-read `AGENTS.md`, point it at that file first:
-`https://raw.githubusercontent.com/garrytan/gbrain/master/AGENTS.md` is the non-Claude
+`https://raw.githubusercontent.com/electricsheephq/eva-brain/master/AGENTS.md` is the non-Claude
 agent operating protocol (install, read order, trust boundary, common tasks). For
 the full doc map, use `llms.txt` at the same URL root.
 
 ### Standalone CLI (no agent)
 
 ```bash
-git clone https://github.com/garrytan/gbrain.git && cd gbrain && bun install && bun link
-gbrain init --pglite --model voyage   # fresh local brain with Voyage 1024d embeddings
-gbrain providers test --model voyage:voyage-3.5
+git clone https://github.com/electricsheephq/eva-brain.git && cd eva-brain && bun install && bun link
+gbrain providers test --model voyage:voyage-4-large
+gbrain init --pglite --embedding-model voyage:voyage-4-large --embedding-dimensions 2048
 gbrain import ~/notes/                # index your markdown
 gbrain query "what themes show up across my notes?"
 ```
 
 If you already have a populated brain, the safest production path for provider/dimension changes is a fresh init plus explicit migration/backup. Preserve the old brain first with `gbrain migrate --to supabase|pglite` or a file backup/export, then re-init against an empty target.
 
-**Do NOT use `bun install -g github:garrytan/gbrain`.** Bun blocks the top-level
+**Do NOT use `bun install -g github:electricsheephq/eva-brain`.** Bun blocks the top-level
 postinstall hook on global installs, so schema migrations never run and the CLI
 aborts with `Aborted()` the first time it opens PGLite. Use `git clone + bun install
 && bun link` as shown above. See [#218](https://github.com/garrytan/gbrain/issues/218).

--- a/docs/guides/provider-install-matrix.md
+++ b/docs/guides/provider-install-matrix.md
@@ -1,9 +1,9 @@
-# Clean integrated install: 1024d embeddings + safe cleanup + verification
+# Clean integrated install: 2048d embeddings + safe cleanup + verification
 
 This is the recommended customer path for your agent fork right now:
 
 1. **archive any old `~/.gbrain` state instead of patching it in place**
-2. **do a fresh init with 1024d embeddings**
+2. **do a fresh init with 2048d embeddings**
 3. **verify provider health and brain health immediately**
 4. **treat host-managed OAuth extraction as a host-side dependency until live-smoked**
 5. **only then import/sync content**
@@ -21,15 +21,15 @@ This branch does **not** yet claim a fully merged end-to-end host-managed OAuth 
 That work is tracked in the downstream adapter issue.
 
 So the honest integrated install story is:
-- **fork side:** fresh 1024d embedding brain + verification
+- **fork side:** fresh 2048d embedding brain + verification
 - **host side:** complete the OAuth adapter/auth setup on the host, then verify extraction there
 - **cut over only after both halves are green**
 
 ## Recommended production target
 
-- embedding provider: **1024d-capable provider**
-- model: **`voyage:voyage-3.5`**
-- embedding dimension: **1024**
+- embedding provider: **2048d-capable provider**
+- model: **`voyage:voyage-4-large`**
+- embedding dimension: **2048**
 - install style: **fresh init**
 - old state handling: **archive, never destructive delete first**
 
@@ -53,10 +53,10 @@ export VOYAGE_API_KEY=...
 # 3) verify provider before init
 gbrain providers list
 gbrain providers explain
-gbrain providers test --model voyage:voyage-3.5
+gbrain providers test --model voyage:voyage-4-large
 
-# 4) fresh init at 1024d
-gbrain init --pglite --embedding-model voyage:voyage-3.5
+# 4) fresh init at 2048d
+gbrain init --pglite --embedding-model voyage:voyage-4-large --embedding-dimensions 2048
 
 # 5) verify the fresh brain
 gbrain doctor --json
@@ -100,14 +100,14 @@ Old customer installs may have any of these problems:
 
 A fresh init is faster and safer than trying to repair every old state shape.
 
-## Fresh init with 1024d embeddings
+## Fresh init with 2048d embeddings
 
 ### PGLite
 
 ```bash
 export VOYAGE_API_KEY=...
-gbrain providers test --model voyage:voyage-3.5
-gbrain init --pglite --embedding-model voyage:voyage-3.5
+gbrain providers test --model voyage:voyage-4-large
+gbrain init --pglite --embedding-model voyage:voyage-4-large --embedding-dimensions 2048
 gbrain doctor --json
 gbrain stats
 ```
@@ -115,15 +115,16 @@ gbrain stats
 ### Supabase / Postgres
 
 Use a fresh target database or fresh customer database URL.
-Do not point a new 1024d install at an old 1536d database.
+Do not point a new 2048d install at an old 1536d database.
 
 ```bash
 export VOYAGE_API_KEY=...
 export GBRAIN_DATABASE_URL='postgresql://...'
 
-gbrain providers test --model voyage:voyage-3.5
+gbrain providers test --model voyage:voyage-4-large
 gbrain init --supabase --non-interactive \
-  --embedding-model voyage:voyage-3.5 \
+  --embedding-model voyage:voyage-4-large \
+  --embedding-dimensions 2048 \
   --url "$GBRAIN_DATABASE_URL"
 
 gbrain doctor --json
@@ -136,14 +137,14 @@ The embedding dimension is schema-level state.
 
 For common providers:
 - OpenAI `text-embedding-3-large` → **1536**
-- 1024d provider model → **1024**
+- 2048d provider model → **2048**
 - Google `text-embedding-004` → **768**
 - Ollama `nomic-embed-text` recipe default → **768**
 - LiteLLM → **must be declared explicitly by the operator**
 
 ### Operational rule
 
-If the install target is 1024d embeddings, initialize the brain that way from the start.
+If the install target is 2048d embeddings, initialize the brain that way from the start.
 Do not reuse a 1536d brain and expect the dimension mismatch to self-heal.
 
 ### Mismatch behavior
@@ -156,14 +157,14 @@ That is expected and correct.
 This part is a **host-side dependency**.
 
 What we can safely document here today:
-- the fork's fresh 1024d install path is independent of host OAuth
+- the fork's fresh 2048d install path is independent of host OAuth
 - the durable host OAuth auth propagation work is tracked in the downstream adapter issue
 - today's media support is text-backed normalized evidence import/search
 - production extraction that relies on host-managed OAuth should be considered dependent on a rebuilt, live-smoked adapter PR
 
 ### Recommended integrated rollout
 
-1. complete the fresh 1024d brain install first
+1. complete the fresh 2048d brain install first
 2. verify it with `gbrain doctor --json` and `gbrain stats`
 3. separately complete the host OAuth adapter/auth flow
 4. verify extraction on the host side
@@ -177,7 +178,7 @@ Because the auth adapter is host-side, the verification should also be host-side
 - no secret values should be printed during verification
 
 Until the downstream adapter issue is proven with a live host runtime smoke, the safe fallback is:
-- use the documented 1024d embedding provider
+- use the documented 2048d embedding provider
 - use normalized media evidence JSON or text-backed extraction paths where applicable
 - do not claim fully supported no-extra-key host-managed OAuth extraction yet
 
@@ -188,13 +189,13 @@ Run these immediately after fresh init:
 ```bash
 gbrain providers list
 gbrain providers explain
-gbrain providers test --model voyage:voyage-3.5
+gbrain providers test --model voyage:voyage-4-large
 gbrain doctor --json
 gbrain stats
 ```
 
 Expected outcomes:
-- provider test succeeds and prints a 1024-dim result
+- provider test succeeds and prints a 2048-dim result
 - doctor reports healthy schema
 - stats returns a working brain with no initialization failure
 
@@ -215,7 +216,7 @@ Expected outcomes after import:
 
 ### Local rollback
 
-If the fresh 1024d install is bad, restore the archived state:
+If the fresh 2048d install is bad, restore the archived state:
 
 ```bash
 rm -rf ~/.gbrain
@@ -240,7 +241,7 @@ gbrain stats
 ### `Embedding dim mismatch`
 
 Cause:
-- a 1024d provider pointed at a 1536d brain, or vice versa
+- a 2048d provider pointed at a 1536d brain, or vice versa
 
 Response:
 - stop retrying
@@ -258,7 +259,7 @@ Response:
 
 ```bash
 gbrain providers env voyage
-gbrain providers test --model voyage:voyage-3.5
+gbrain providers test --model voyage:voyage-4-large
 ```
 
 Fix the env/setup first, then rerun init.
@@ -276,7 +277,7 @@ Response:
 If you're installing this fork for a customer today, the safest story is:
 
 1. archive old `~/.gbrain`
-2. fresh init with 1024d embeddings
+2. fresh init with 2048d embeddings
 3. verify provider + brain health immediately
 4. treat host OAuth extraction as a separately verified dependency
 5. only import customer data after both sides are green

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1291,7 +1291,8 @@ Source: https://raw.githubusercontent.com/garrytan/gbrain/master/INSTALL_FOR_AGE
 
 # GBrain Installation Guide for AI Agents
 
-Read this entire file, then follow the steps. Ask the user for API keys when needed.
+Read this entire file, then follow the steps. Ask the user for `VOYAGE_API_KEY`
+only if the local environment does not already provide it.
 Target: ~30 minutes to a fully working brain.
 
 ## Step 0: If you are not Claude Code
@@ -1301,14 +1302,14 @@ protocol (install, read order, trust boundary, common tasks). Claude Code reads
 `CLAUDE.md` automatically and can skip ahead.
 
 If you fetched this file by URL without cloning yet, the companion files live at:
-- `https://raw.githubusercontent.com/garrytan/gbrain/master/AGENTS.md` — start here
-- `https://raw.githubusercontent.com/garrytan/gbrain/master/llms.txt` — full doc map
-- `https://raw.githubusercontent.com/garrytan/gbrain/master/llms-full.txt` — same map, inlined
+- `https://raw.githubusercontent.com/electricsheephq/eva-brain/master/AGENTS.md` — start here
+- `https://raw.githubusercontent.com/electricsheephq/eva-brain/master/llms.txt` — full doc map
+- `https://raw.githubusercontent.com/electricsheephq/eva-brain/master/llms-full.txt` — same map, inlined
 
 ## Step 1: Install GBrain
 
 ```bash
-git clone https://github.com/garrytan/gbrain.git ~/gbrain && cd ~/gbrain
+git clone https://github.com/electricsheephq/eva-brain.git ~/eva-brain && cd ~/eva-brain
 curl -fsSL https://bun.sh/install | bash
 export PATH="$HOME/.bun/bin:$PATH"
 bun install && bun link
@@ -1317,46 +1318,96 @@ bun install && bun link
 Verify: `gbrain --version` should print a version number. If `gbrain` is not found,
 restart the shell or add the PATH export to the shell profile.
 
-> **Do NOT use `bun install -g github:garrytan/gbrain`.** Bun blocks the top-level
+> **Do NOT use `bun install -g github:electricsheephq/eva-brain`.** Bun blocks the top-level
 > postinstall hook on global installs, so schema migrations never run and the CLI
 > aborts with `Aborted()` when it opens PGLite. Use the `git clone + bun link` path
 > above. Tracking issue: [#218](https://github.com/garrytan/gbrain/issues/218).
 
 ## Step 2: AI Provider Setup
 
-Default path:
+Default Eva/OpenClaw path:
 
 ```bash
-export OPENAI_API_KEY=sk-...
-export ANTHROPIC_API_KEY=sk-ant-...   # optional, improves search quality
+export VOYAGE_API_KEY=...
 ```
 
-Save to shell profile or `.env`.
+Save it to the shell profile or to `~/.gbrain/gbrain.env`. Voyage is for
+embeddings. OpenClaw/Codex OAuth is used by the OpenClaw plugin for extraction;
+do not ask users for an OpenAI API key just to run Eva Brain extraction.
 
 Before initializing the brain, verify the provider you plan to use:
 
 ```bash
 gbrain providers list
 gbrain providers explain
-gbrain providers test --model openai:text-embedding-3-large
+gbrain providers test --model voyage:voyage-4-large
 ```
 
 Without an embedding provider, keyword search still works but semantic/hybrid retrieval will not.
-Without Anthropic, search works but skips Anthropic-backed expansion.
 
-If you want Voyage, Google, Ollama, or LiteLLM instead of OpenAI, read:
+If you want Google, Ollama, LiteLLM, or another provider instead of Voyage, read:
 
 - `docs/guides/provider-install-matrix.md` — provider matrix, exact init commands, dimension contract, rollback notes
 - `docs/GBRAIN_VERIFY.md` — post-install verification checklist
 
-**OpenClaw Codex OAuth note:** this install guide only documents verified API-key-backed provider setup today. Durable OpenClaw-managed Codex/OpenAI OAuth wiring is tracked separately in `100yenadmin/eva-brain#2`.
+**OpenClaw Codex OAuth note:** the OpenClaw plugin exposes `/plugins/gbrain/extract`
+and routes extraction through OpenClaw's logged-in Codex runtime. The GBrain CLI
+still needs a gateway URL/token when calling that route from outside OpenClaw,
+but the extraction model auth is owned by OpenClaw, not by a user-supplied
+OpenAI API key.
 
 ## Step 3: Create the Brain
 
 ```bash
-gbrain init                           # PGLite, no server needed
+gbrain init --pglite --embedding-model voyage:voyage-4-large --embedding-dimensions 2048
 gbrain doctor --json                  # verify all checks pass
 ```
+
+## Step 3.5: Install The OpenClaw Plugin
+
+If OpenClaw is installed on this machine, install the native plugin from the
+same Eva Brain checkout:
+
+```bash
+cd ~/eva-brain
+openclaw plugins install --dangerously-force-unsafe-install ./plugins/openclaw-gbrain
+openclaw plugins enable gbrain
+openclaw gateway restart
+openclaw plugins inspect gbrain --runtime --json
+openclaw gbrain status
+```
+
+The plugin provides:
+
+- `gbrain_status`
+- `gbrain_search`
+- `gbrain_query`
+- `/plugins/gbrain/extract` for OAuth-backed extraction through OpenClaw/Codex
+
+If OpenClaw is not installed, skip this step and keep the CLI/MCP path.
+
+## Step 3.6: Install The OpenClaw Support KB
+
+For OpenClaw customer/support work, install the KB source and support skills
+after GBrain is healthy:
+
+```bash
+export OPENCLAW_SUPPORT_KB_REPO="https://github.com/electricsheephq/openclaw-support-kb.git"
+export OPENCLAW_SUPPORT_KB_DIR="$HOME/.gbrain/sources/openclaw-support-kb"
+
+if [ -d "$OPENCLAW_SUPPORT_KB_DIR/.git" ]; then
+  git -C "$OPENCLAW_SUPPORT_KB_DIR" pull --ff-only
+else
+  git clone "$OPENCLAW_SUPPORT_KB_REPO" "$OPENCLAW_SUPPORT_KB_DIR"
+fi
+
+cd "$OPENCLAW_SUPPORT_KB_DIR"
+node scripts/update-client.mjs
+node scripts/status.mjs
+```
+
+This installs the four OpenClaw support skills and registers the
+`openclaw-support-kb` GBrain source.
 
 The user's markdown files (notes, docs, brain repo) are SEPARATE from this tool repo.
 Ask the user where their files are, or create a new brain repo:
@@ -1365,9 +1416,9 @@ Ask the user where their files are, or create a new brain repo:
 mkdir -p ~/brain && cd ~/brain && git init
 ```
 
-Read `~/gbrain/docs/GBRAIN_RECOMMENDED_SCHEMA.md` and set up the MECE directory
+Read `~/eva-brain/docs/GBRAIN_RECOMMENDED_SCHEMA.md` and set up the MECE directory
 structure (people/, companies/, concepts/, etc.) inside the user's brain repo,
-NOT inside ~/gbrain.
+NOT inside `~/eva-brain`.
 
 ## Step 4: Import and Index
 
@@ -1403,7 +1454,7 @@ and supports `--since YYYY-MM-DD` for incremental runs.
 
 ## Step 5: Load Skills
 
-Read `~/gbrain/skills/RESOLVER.md`. This is the skill dispatcher. It tells you which
+Read `~/eva-brain/skills/RESOLVER.md`. This is the skill dispatcher. It tells you which
 skill to read for any task. Save this to your memory permanently.
 
 The three most important skills to adopt immediately:
@@ -1444,7 +1495,7 @@ Set up using your platform's scheduler (OpenClaw cron, Railway cron, crontab):
 
 ## Step 8: Integrations
 
-Run `gbrain integrations list`. Each recipe in `~/gbrain/recipes/` is a self-contained
+Run `gbrain integrations list`. Each recipe in `~/eva-brain/recipes/` is a self-contained
 installer. It tells you what credentials to ask for, how to validate, and what cron
 to register. Ask the user which integrations they want (email, calendar, voice, Twitter).
 
@@ -1458,12 +1509,12 @@ actually works) is the most important.
 ## Upgrade
 
 ```bash
-cd ~/gbrain && git pull origin master && bun install
+cd ~/eva-brain && git pull origin master && bun install
 gbrain init                           # apply schema migrations (idempotent)
 gbrain post-upgrade                   # show migration notes for the version range
 ```
 
-Then read `~/gbrain/skills/migrations/v<NEW_VERSION>.md` (and any intermediate
+Then read `~/eva-brain/skills/migrations/v<NEW_VERSION>.md` (and any intermediate
 versions you skipped) and run any backfill or verification steps it lists. Skipping
 this is how features ship in the binary but stay dormant in the user's brain.
 
@@ -1641,7 +1692,7 @@ GBrain is those patterns, generalized. 34 skills. Install in 30 minutes. Your ag
 
 **New in v0.25.0 — BrainBench-Real (session capture, contributor opt-in):** with `GBRAIN_CONTRIBUTOR_MODE=1` set in your shell, every real `query` + `search` call through MCP, CLI, or the subagent tool-bridge gets captured (PII-scrubbed) into an `eval_candidates` table. Snapshot with `gbrain eval export`, replay against your code change with `gbrain eval replay`. Three numbers come back: mean Jaccard@k between captured and current retrieved slugs, top-1 stability, and latency Δ. **Off by default** for production users — no surprise data accumulation. Walkthrough: [docs/eval-bench.md](docs/eval-bench.md). NDJSON wire format: [docs/eval-capture.md](docs/eval-capture.md).
 
-> **~30 minutes to a fully working brain.** Database ready in 2 seconds (PGLite, no server). You just answer questions about API keys.
+> **~30 minutes to a fully working brain.** Database ready in 2 seconds (PGLite, no server). For Eva/OpenClaw installs, Voyage powers embeddings and OpenClaw's logged-in Codex runtime powers extraction.
 
 > **LLMs:** fetch [`llms.txt`](llms.txt) for the documentation map, or [`llms-full.txt`](llms-full.txt) for the same map with core docs inlined in one fetch. **Agents:** start with [`AGENTS.md`](AGENTS.md) (or [`CLAUDE.md`](CLAUDE.md) if you're Claude Code).
 
@@ -1658,31 +1709,31 @@ Paste this into your agent:
 
 ```
 Retrieve and follow the instructions at:
-https://raw.githubusercontent.com/garrytan/gbrain/master/INSTALL_FOR_AGENTS.md
+https://raw.githubusercontent.com/electricsheephq/eva-brain/master/INSTALL_FOR_AGENTS.md
 ```
 
-That's it. The agent clones the repo, installs GBrain, sets up the brain, loads 34 skills, and configures recurring jobs. You answer a few questions about API keys. ~30 minutes.
+That's it. The agent clones Eva Brain, installs GBrain, sets up a Voyage 4 Large 2048d brain when `VOYAGE_API_KEY` is available, installs the OpenClaw plugin, and verifies the local doctor score. ~30 minutes.
 
-For provider choice, embedding dimensions, Voyage 1024d migration, and the current OpenClaw Codex OAuth dependency boundary, read [`docs/guides/provider-install-matrix.md`](docs/guides/provider-install-matrix.md).
+For provider choice, embedding dimensions, Voyage 4 Large 2048d setup, and the OpenClaw Codex OAuth extraction boundary, read [`docs/guides/provider-install-matrix.md`](docs/guides/provider-install-matrix.md).
 
 If your agent doesn't auto-read `AGENTS.md`, point it at that file first:
-`https://raw.githubusercontent.com/garrytan/gbrain/master/AGENTS.md` is the non-Claude
+`https://raw.githubusercontent.com/electricsheephq/eva-brain/master/AGENTS.md` is the non-Claude
 agent operating protocol (install, read order, trust boundary, common tasks). For
 the full doc map, use `llms.txt` at the same URL root.
 
 ### Standalone CLI (no agent)
 
 ```bash
-git clone https://github.com/garrytan/gbrain.git && cd gbrain && bun install && bun link
-gbrain init --pglite --model voyage   # fresh local brain with Voyage 1024d embeddings
-gbrain providers test --model voyage:voyage-3.5
+git clone https://github.com/electricsheephq/eva-brain.git && cd eva-brain && bun install && bun link
+gbrain providers test --model voyage:voyage-4-large
+gbrain init --pglite --embedding-model voyage:voyage-4-large --embedding-dimensions 2048
 gbrain import ~/notes/                # index your markdown
 gbrain query "what themes show up across my notes?"
 ```
 
 If you already have a populated brain, the safest production path for provider/dimension changes is a fresh init plus explicit migration/backup. Preserve the old brain first with `gbrain migrate --to supabase|pglite` or a file backup/export, then re-init against an empty target.
 
-**Do NOT use `bun install -g github:garrytan/gbrain`.** Bun blocks the top-level
+**Do NOT use `bun install -g github:electricsheephq/eva-brain`.** Bun blocks the top-level
 postinstall hook on global installs, so schema migrations never run and the CLI
 aborts with `Aborted()` the first time it opens PGLite. Use `git clone + bun install
 && bun link` as shown above. See [#218](https://github.com/garrytan/gbrain/issues/218).

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,25 +1,25 @@
 {
   "name": "gbrain",
-  "version": "0.25.1",
-  "description": "Personal knowledge brain with Postgres + pgvector hybrid search",
+  "version": "0.27.0",
+  "description": "Eva Brain/GBrain skills and personal knowledge brain with provider-neutral hybrid search",
   "family": "bundle-plugin",
   "configSchema": {
     "database_url": {
       "type": "string",
-      "required": true,
-      "description": "PostgreSQL connection URL (Supabase recommended)",
+      "required": false,
+      "description": "Optional PostgreSQL connection URL. Omit for local PGLite.",
       "uiHints": { "sensitive": true }
     },
-    "openai_api_key": {
+    "voyage_api_key": {
       "type": "string",
       "required": false,
-      "description": "OpenAI API key for embeddings (uses OPENAI_API_KEY env var if not set)",
+      "description": "Optional Voyage API key for Voyage 4 Large embeddings (uses VOYAGE_API_KEY env var if not set)",
       "uiHints": { "sensitive": true }
     }
   },
   "mcpServers": {
     "gbrain": {
-      "command": "./bin/gbrain",
+      "command": "gbrain",
       "args": ["serve"]
     }
   },

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "gbrain",
   "version": "0.27.0",
   "description": "Postgres-native personal knowledge brain with hybrid RAG search",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/electricsheephq/eva-brain.git"
+  },
   "type": "module",
   "main": "src/core/index.ts",
   "bin": {
@@ -54,13 +58,16 @@
     "check:exports-count": "scripts/check-exports-count.sh",
     "check:admin-build": "scripts/check-admin-build.sh",
     "check:test-isolation": "scripts/check-test-isolation.sh",
-    "postinstall": "command -v gbrain >/dev/null 2>&1 && gbrain apply-migrations --yes --non-interactive || echo '[gbrain] postinstall skipped. If installed via bun install -g github:...: run `gbrain doctor` and `gbrain apply-migrations --yes` manually. See https://github.com/garrytan/gbrain/issues/218' 1>&2",
+    "postinstall": "echo '[gbrain] dependencies installed. Run `bun link`, then `gbrain init --pglite` or follow INSTALL_FOR_AGENTS.md.' 1>&2",
     "prepublish:clawhub": "bun run build:all",
     "publish:clawhub": "clawhub package publish . --family bundle-plugin"
   },
   "openclaw": {
     "compat": {
       "pluginApi": ">=2026.4.0"
+    },
+    "build": {
+      "openclawVersion": ">=2026.5.3"
     }
   },
   "dependencies": {

--- a/plugins/openclaw-gbrain/README.md
+++ b/plugins/openclaw-gbrain/README.md
@@ -14,7 +14,18 @@ logged-in OpenClaw/Codex runtime instead of asking users for a model API key.
 
 ## Install
 
-From an Eva Brain checkout:
+From a fresh Eva Brain checkout:
+
+```bash
+git clone https://github.com/electricsheephq/eva-brain.git ~/eva-brain
+cd ~/eva-brain
+curl -fsSL https://bun.sh/install | bash
+export PATH="$HOME/.bun/bin:$PATH"
+bun install && bun link
+gbrain --version
+```
+
+Then install the OpenClaw plugin from the same checkout:
 
 ```bash
 openclaw plugins install --dangerously-force-unsafe-install ./plugins/openclaw-gbrain
@@ -23,7 +34,7 @@ openclaw gateway restart
 openclaw plugins inspect gbrain --runtime --json
 ```
 
-This first bridge intentionally shells out to the reviewed local `gbrain` and
+This bridge intentionally shells out to the reviewed local `gbrain` and
 `openclaw` CLIs. OpenClaw's install scanner therefore requires the explicit
 unsafe-install override. The plugin does not accept arbitrary command strings;
 the command paths are configurable and arguments are built internally.
@@ -76,7 +87,9 @@ only after the local OpenClaw/Codex runtime is proven to tolerate the extra load
 
 ```bash
 gbrain --version
+gbrain health
 openclaw infer model run --gateway --model openai-codex/gpt-5.4-mini --prompt 'Return only JSON: {"ok":true}' --json
+openclaw gbrain status
 ```
 
 Then call `gbrain ingest-media --extract openclaw` with

--- a/plugins/openclaw-gbrain/package.json
+++ b/plugins/openclaw-gbrain/package.json
@@ -4,6 +4,11 @@
   "description": "OpenClaw native plugin for Eva Brain/GBrain search, query, and OAuth-backed media extraction.",
   "type": "module",
   "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/electricsheephq/eva-brain.git",
+    "directory": "plugins/openclaw-gbrain"
+  },
   "files": [
     "index.js",
     "openclaw.plugin.json",
@@ -15,6 +20,9 @@
     ],
     "compat": {
       "pluginApi": ">=2026.5.3"
+    },
+    "build": {
+      "openclawVersion": ">=2026.5.3"
     }
   },
   "license": "MIT"

--- a/src/commands/apply-migrations.ts
+++ b/src/commands/apply-migrations.ts
@@ -163,10 +163,17 @@ interface Plan {
  */
 function buildPlan(idx: CompletedIndex, installed: string, filterVersion?: string): Plan {
   const plan: Plan = { applied: [], partial: [], pending: [], skippedFuture: [], wedged: [] };
+  const completedVersions = Array.from(idx.byVersion.entries())
+    .filter(([, entries]) => entries.some(e => e.status === 'complete'))
+    .map(([version]) => version);
   for (const m of migrations) {
     if (filterVersion && m.version !== filterVersion) continue;
     if (compareVersions(m.version, installed) > 0) {
       plan.skippedFuture.push(m);
+      continue;
+    }
+    if (completedVersions.some(version => compareVersions(version, m.version) >= 0)) {
+      plan.applied.push(m);
       continue;
     }
     const status = statusForVersion(m.version, idx);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -10,6 +10,8 @@ import { saveConfig, loadConfig, toEngineConfig, gbrainPath, type GBrainConfig }
 import { createEngine } from '../core/engine-factory.ts';
 import { getRecipe } from '../core/ai/recipes/index.ts';
 import { configureGateway } from '../core/ai/gateway.ts';
+import { appendCompletedMigration, loadCompletedMigrations } from '../core/preferences.ts';
+import { migrations } from './migrations/index.ts';
 
 export async function runInit(args: string[]) {
   const isSupabase = args.includes('--supabase');
@@ -216,9 +218,10 @@ async function initPGLite(opts: {
 }) {
   const dbPath = opts.customPath || gbrainPath('brain.pglite');
   console.log(`Setting up local brain with PGLite (no server needed)...`);
+  const existingConfig = loadConfig();
 
   const mergedConfig: GBrainConfig = {
-    ...(loadConfig() ?? { engine: 'pglite', database_path: dbPath }),
+    ...(existingConfig ?? { engine: 'pglite', database_path: dbPath }),
     engine: 'pglite',
     database_path: dbPath,
     ...(opts.aiOpts?.embedding_model ? { embedding_model: opts.aiOpts.embedding_model } : {}),
@@ -245,6 +248,7 @@ async function initPGLite(opts: {
       ...(opts.apiKey ? { openai_api_key: opts.apiKey } : {}),
     };
     saveConfig(config);
+    recordFreshInstallMigrationBaseline(existingConfig === null);
 
     const stats = await engine.getStats();
 
@@ -280,9 +284,10 @@ async function initPostgres(opts: {
   aiOpts?: { embedding_model?: string; embedding_dimensions?: number; expansion_model?: string; chat_model?: string };
 }) {
   const { databaseUrl } = opts;
+  const existingConfig = loadConfig();
 
   const mergedConfig: GBrainConfig = {
-    ...(loadConfig() ?? { engine: 'postgres', database_url: databaseUrl }),
+    ...(existingConfig ?? { engine: 'postgres', database_url: databaseUrl }),
     engine: 'postgres',
     database_url: databaseUrl,
     ...(opts.aiOpts?.embedding_model ? { embedding_model: opts.aiOpts.embedding_model } : {}),
@@ -352,6 +357,7 @@ async function initPostgres(opts: {
       ...(opts.apiKey ? { openai_api_key: opts.apiKey } : {}),
     };
     saveConfig(config);
+    recordFreshInstallMigrationBaseline(existingConfig === null);
     console.log('Config saved to ~/.gbrain/config.json');
 
     const stats = await engine.getStats();
@@ -375,6 +381,18 @@ async function initPostgres(opts: {
     }
   } finally {
     try { await engine.disconnect(); } catch { /* best-effort */ }
+  }
+}
+
+function recordFreshInstallMigrationBaseline(isFreshInstall: boolean): void {
+  if (!isFreshInstall) return;
+  if (loadCompletedMigrations().length > 0) return;
+  for (const migration of migrations) {
+    appendCompletedMigration({
+      version: migration.version,
+      status: 'complete',
+      fresh_install_baseline: true,
+    });
   }
 }
 

--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -427,7 +427,7 @@ function pickRecommended(options: ProviderOption[], env: Record<string, boolean>
   }
   if (env.VOYAGE_API_KEY) {
     const voyage = embOpts.find(o => o.id.startsWith('voyage:'));
-    if (voyage) return { id: voyage.id, reason: 'VOYAGE_API_KEY set — Voyage at 1024 dims.' };
+    if (voyage) return { id: voyage.id, reason: 'VOYAGE_API_KEY set — Voyage at 2048 dims.' };
   }
   return {
     id: 'openai:text-embedding-3-large',

--- a/src/core/ai/recipes/voyage.ts
+++ b/src/core/ai/recipes/voyage.ts
@@ -16,13 +16,11 @@ export const voyage: Recipe = {
   },
   touchpoints: {
     embedding: {
-      // eva-brain's production path uses a 1024-dimensional schema. voyage-3-lite
-      // returns 512 dimensions and is intentionally excluded from the default
-      // supported list until per-model dimensions are exposed in provider config.
-      models: ['voyage-3.5', 'voyage-4-large', 'voyage-4', 'voyage-3-large', 'voyage-3'],
-      default_dims: 1024,
+      // Voyage 4/3.5/code models support output_dimension values including 2048.
+      models: ['voyage-4-large', 'voyage-4', 'voyage-4-lite', 'voyage-code-3', 'voyage-3.5', 'voyage-3.5-lite', 'voyage-3-large', 'voyage-3'],
+      default_dims: 2048,
       cost_per_1m_tokens_usd: 0.18,
-      price_last_verified: '2026-04-20',
+      price_last_verified: '2026-05-05',
     },
   },
   setup_hint: 'Get an API key at https://dash.voyageai.com/api-keys, then `export VOYAGE_API_KEY=...`',

--- a/src/core/preferences.ts
+++ b/src/core/preferences.ts
@@ -13,6 +13,17 @@ import { join } from 'path';
 import { homedir } from 'os';
 
 function home(): string {
+  const override = process.env.GBRAIN_HOME;
+  if (override && override.trim()) {
+    const trimmed = override.trim();
+    if (!trimmed.startsWith('/')) {
+      throw new Error(`GBRAIN_HOME must be an absolute path; got: ${trimmed}`);
+    }
+    if (trimmed.split('/').includes('..')) {
+      throw new Error(`GBRAIN_HOME must not contain '..' segments; got: ${trimmed}`);
+    }
+    return trimmed;
+  }
   // `os.homedir()` in Bun caches its initial value and ignores later
   // `process.env.HOME` mutations, which breaks test isolation and any
   // workflow that needs to run against a specific $HOME (CI, scripted installs).

--- a/test/apply-migrations.test.ts
+++ b/test/apply-migrations.test.ts
@@ -118,6 +118,28 @@ describe('buildPlan — diff against completed + installed VERSION', () => {
     expect(plan.pending).toEqual([]);
   });
 
+  test('later completed migration supersedes older partial/pending ledger noise', () => {
+    const idx = indexCompleted([
+      { version: '0.11.0', status: 'partial' },
+      { version: '0.11.0', status: 'partial' },
+      { version: '0.11.0', status: 'partial' },
+      { version: '0.12.0', status: 'partial' },
+      { version: '0.16.0', status: 'complete' },
+    ]);
+    const plan = buildPlan(idx, '0.27.0');
+    expect(plan.applied.map(m => m.version)).toEqual([
+      '0.11.0',
+      '0.12.0',
+      '0.12.2',
+      '0.13.0',
+      '0.13.1',
+      '0.14.0',
+      '0.16.0',
+    ]);
+    expect(plan.wedged.map(m => m.version)).not.toContain('0.11.0');
+    expect(plan.partial.map(m => m.version)).not.toContain('0.12.0');
+  });
+
   test('stopgap wrote partial → v0.11.0 lands in `partial` bucket (resumable)', () => {
     const idx = indexCompleted([
       { version: '0.11.0', status: 'partial', apply_migrations_pending: true },

--- a/test/preferences.test.ts
+++ b/test/preferences.test.ts
@@ -174,6 +174,22 @@ describe('loadCompletedMigrations', () => {
     expect(loadCompletedMigrations()).toEqual([]);
   });
 
+  test('honors GBRAIN_HOME for migration ledger isolation', () => {
+    const gbrainHome = mkdtempSync(join(tmpdir(), 'gbrain-prefs-gbrain-home-'));
+    const previous = process.env.GBRAIN_HOME;
+    process.env.GBRAIN_HOME = gbrainHome;
+    try {
+      appendCompletedMigration({ version: '9.9.9', status: 'complete' });
+      expect(existsSync(join(gbrainHome, '.gbrain', 'migrations', 'completed.jsonl'))).toBe(true);
+      expect(existsSync(join(tmp, '.gbrain', 'migrations', 'completed.jsonl'))).toBe(false);
+      expect(loadCompletedMigrations().map(entry => entry.version)).toEqual(['9.9.9']);
+    } finally {
+      if (previous === undefined) delete process.env.GBRAIN_HOME;
+      else process.env.GBRAIN_HOME = previous;
+      rmSync(gbrainHome, { recursive: true, force: true });
+    }
+  });
+
   test('parses valid JSONL lines', () => {
     appendCompletedMigration({ version: '0.10.0', status: 'complete' });
     appendCompletedMigration({ version: '0.11.0', status: 'partial' });

--- a/test/skillpack-check.test.ts
+++ b/test/skillpack-check.test.ts
@@ -68,6 +68,19 @@ describe('gbrain skillpack-check', () => {
     expect(report.ts).toBeTruthy();
   });
 
+  test('fresh initialized PGLite brain → no obsolete migration repair action', () => {
+    const init = run(['init', '--pglite', '--embedding-model', 'voyage:voyage-4-large', '--embedding-dimensions', '2048', '--json']);
+    expect(init.exitCode).toBe(0);
+
+    const result = run(['skillpack-check']);
+    expect(result.exitCode).toBe(0);
+    const report = JSON.parse(result.stdout);
+    expect(report.healthy).toBe(true);
+    expect(report.actions).not.toContain('gbrain apply-migrations --yes');
+    expect(report.migrations.pending_count).toBe(0);
+    expect(report.migrations.partial_count).toBe(0);
+  }, 60_000);
+
   test('half-migrated (partial completed.jsonl) → exit 1, apply-migrations in actions', () => {
     const migrationsDir = join(tmp, '.gbrain', 'migrations');
     mkdirSync(migrationsDir, { recursive: true });


### PR DESCRIPTION
Closes #45.

## What changed

This makes Eva Brain installable as the repo-owned OpenClaw/GBrain package we actually want to hand to agents.

- adds Voyage 4/3.5/code model IDs to the Voyage recipe and sets Voyage 4 Large to 2048d by default
- keeps provider guidance pointed at `voyage:voyage-4-large` + `2048` for technical docs
- makes `GBRAIN_HOME` isolate preferences and migration ledgers for clean canaries and fleet installs
- records fresh-install migration baselines so a brand-new PGLite brain does not immediately ask agents to run obsolete repairs
- treats later completed migrations as superseding older partial ledger noise
- updates OpenClaw plugin/package metadata and install docs to the canonical Eva/OpenClaw Support KB repos
- regenerates `llms-full.txt` so agents fetching the one-file doc map see Eva install instructions, not upstream/Garry defaults

## Why

The local canary found the failure mode we care about before rollout: GBrain was technically installed, but the install path could still pick stale code, reject the configured Voyage model, or leave the KB source needing manual repair. This PR moves those fixes into the package and docs so a new agent starts from the correct path.

```mermaid
flowchart TD
  A[Agent receives Eva Brain repo link] --> B[Clone Eva Brain]
  B --> C[bun install && bun link]
  C --> D[Test Voyage 4 Large]
  D --> E[Fresh PGLite init 2048d]
  E --> F[Install OpenClaw plugin]
  F --> G[Install Support KB]
  G --> H[Doctor/search/skill smoke]
```

## Human walkthrough

For a nontechnical user: Eva Brain is the local company brain. OpenClaw uses it to remember and search docs. Voyage turns docs into searchable meaning. The Support KB is just one source inside that brain, focused on OpenClaw support answers. After this PR, an agent should be able to follow the repo install doc and set up the brain, plugin, and KB without discovering old local binaries or hand-fixing migration warnings.

## Validation

- `bun run verify` -> pass
- focused migration/provider/Voyage tests -> 79 pass, 0 fail
- `bun run test` -> 3933 pass, 0 fail
- OpenClaw plugin preflight -> `ok: true`
- live `gbrain providers test --model voyage:voyage-4-large` -> 2048 dims
- live `gbrain doctor --json` after KB sync -> `status: healthy`, `health_score: 100`
- live Support KB status -> healthy, search probes pass, source checkout clean

## Follow-up canary

After merge, run a throwaway clean-home install using the public repo URLs only. This is intentionally separate from the warmed local checkout so we can prove the one-link path before fleet rollout.
