### PR TITLE
fix: load GBrain env and source-scope stale embeds

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { readFileSync } from 'fs';
-import { loadConfig, toEngineConfig } from './core/config.ts';
+import { loadConfig, loadGbrainEnv, toEngineConfig } from './core/config.ts';
 import type { BrainEngine } from './core/engine.ts';
 import { operations, OperationError } from './core/operations.ts';
 import type { Operation, OperationContext } from './core/operations.ts';
@@ -630,7 +630,8 @@ async function handleCliOnly(command: string, args: string[]) {
 }
 
 async function connectEngine(): Promise<BrainEngine> {
-  const config = loadConfig();
+  const env = loadGbrainEnv();
+  const config = loadConfig(env);
   if (!config) {
     console.error('No brain configured. Run: gbrain init');
     process.exit(1);
@@ -647,7 +648,7 @@ async function connectEngine(): Promise<BrainEngine> {
     chat_fallback_chain: config.chat_fallback_chain,
     base_urls: config.provider_base_urls,
     provider_auth: config.provider_auth,
-    env: { ...process.env },
+    env,
   });
 
   const { createEngine } = await import('./core/engine-factory.ts');

--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -360,15 +360,18 @@ async function embedAllStale(
 
   // Pull only the stale chunks (no embedding column).
   const staleRows = await engine.listStaleChunks();
-  // Group by slug so each slug → array of stale chunks for batched embedding.
-  const bySlug = new Map<string, typeof staleRows>();
+  // Group by composite page identity so duplicate slugs in different sources
+  // re-embed their own chunks instead of falling back to source_id=default.
+  const byPage = new Map<string, { sourceId: string; slug: string; rows: typeof staleRows }>();
   for (const row of staleRows) {
-    const list = bySlug.get(row.slug);
-    if (list) list.push(row);
-    else bySlug.set(row.slug, [row]);
+    const sourceId = row.source_id || 'default';
+    const key = `${sourceId}\0${row.slug}`;
+    const group = byPage.get(key);
+    if (group) group.rows.push(row);
+    else byPage.set(key, { sourceId, slug: row.slug, rows: [row] });
   }
 
-  const slugs = Array.from(bySlug.keys());
+  const groups = Array.from(byPage.values());
   const totalStaleChunks = staleRows.length;
   result.total_chunks += totalStaleChunks;
   // skipped is "chunks we considered and skipped due to having an embedding".
@@ -378,21 +381,21 @@ async function embedAllStale(
 
   if (dryRun) {
     result.would_embed += totalStaleChunks;
-    result.pages_processed += slugs.length;
+    result.pages_processed += groups.length;
     if (onProgress) {
       // Emit a single tick to satisfy the contract (CLI progress reporters
       // expect at least one start/finish pair).
-      onProgress(slugs.length, slugs.length, 0);
+      onProgress(groups.length, groups.length, 0);
     }
-    console.log(`[dry-run] Would embed ${totalStaleChunks} chunks across ${slugs.length} pages`);
+    console.log(`[dry-run] Would embed ${totalStaleChunks} chunks across ${groups.length} pages`);
     return;
   }
 
   const CONCURRENCY = parseInt(process.env.GBRAIN_EMBED_CONCURRENCY || '20', 10);
   let processed = 0;
 
-  async function embedOneSlug(slug: string) {
-    const stale = bySlug.get(slug)!;
+  async function embedOneGroup(group: { sourceId: string; slug: string; rows: typeof staleRows }) {
+    const stale = group.rows;
     try {
       const embeddings = await embedBatch(stale.map(c => c.chunk_text));
       // CRITICAL: passing ONLY the stale indices to upsertChunks would
@@ -401,7 +404,7 @@ async function embedAllStale(
       // re-fetch existing chunks for this page and merge. Bounded by the
       // stale slug count, not by total slugs — autopilot common case
       // is 0 stale (pre-flight short-circuit, never reaches this path).
-      const existing = await engine.getChunks(slug);
+      const existing = await engine.getChunks(group.slug, { sourceId: group.sourceId });
       const staleIdxToEmbedding = new Map<number, Float32Array>();
       for (let j = 0; j < stale.length; j++) {
         staleIdxToEmbedding.set(stale[j].chunk_index, embeddings[j]);
@@ -415,26 +418,26 @@ async function embedAllStale(
         embedding: staleIdxToEmbedding.get(c.chunk_index) ?? undefined,
         token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
       }));
-      await engine.upsertChunks(slug, merged);
+      await engine.upsertChunks(group.slug, merged, { sourceId: group.sourceId });
       result.embedded += stale.length;
     } catch (e: unknown) {
-      console.error(`\n  Error embedding ${slug}: ${e instanceof Error ? e.message : e}`);
+      console.error(`\n  Error embedding ${group.sourceId}:${group.slug}: ${e instanceof Error ? e.message : e}`);
     }
     processed++;
     result.pages_processed++;
-    onProgress?.(processed, slugs.length, result.embedded);
+    onProgress?.(processed, groups.length, result.embedded);
   }
 
   let nextIdx = 0;
   async function worker() {
-    while (nextIdx < slugs.length) {
+    while (nextIdx < groups.length) {
       const idx = nextIdx++;
-      await embedOneSlug(slugs[idx]);
+      await embedOneGroup(groups[idx]);
     }
   }
 
-  const numWorkers = Math.min(CONCURRENCY, slugs.length);
+  const numWorkers = Math.min(CONCURRENCY, groups.length);
   await Promise.all(Array.from({ length: numWorkers }, () => worker()));
 
-  console.log(`Embedded ${result.embedded} chunks across ${slugs.length} pages`);
+  console.log(`Embedded ${result.embedded} chunks across ${groups.length} pages`);
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,7 +6,7 @@ import { homedir } from 'os';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-import { saveConfig, loadConfig, toEngineConfig, gbrainPath, type GBrainConfig } from '../core/config.ts';
+import { saveConfig, loadConfig, loadGbrainEnv, toEngineConfig, gbrainPath, type GBrainConfig } from '../core/config.ts';
 import { createEngine } from '../core/engine-factory.ts';
 import { getRecipe } from '../core/ai/recipes/index.ts';
 import { configureGateway } from '../core/ai/gateway.ts';
@@ -177,7 +177,7 @@ function configureGatewayFromConfig(config: GBrainConfig): void {
     chat_fallback_chain: config.chat_fallback_chain,
     base_urls: config.provider_base_urls,
     provider_auth: config.provider_auth,
-    env: { ...process.env },
+    env: loadGbrainEnv(),
   });
 }
 

--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -9,7 +9,7 @@ import { resolveProviderAuth, redactAuthResolution } from '../core/ai/auth.ts';
 import { listRecipes, getRecipe } from '../core/ai/recipes/index.ts';
 import { configureGateway, embedOne, isAvailable as gwIsAvailable, chat as gwChat } from '../core/ai/gateway.ts';
 import { probeOllama, probeLMStudio } from '../core/ai/probes.ts';
-import { loadConfig } from '../core/config.ts';
+import { loadConfig, loadGbrainEnv } from '../core/config.ts';
 import { AIConfigError, AITransientError } from '../core/ai/errors.ts';
 import type { AIGatewayConfig, AuthSourceClass, Recipe } from '../core/ai/types.ts';
 
@@ -36,7 +36,8 @@ interface ProviderOption {
 let gatewayConfig: AIGatewayConfig;
 
 function configureFromEnv(): void {
-  const config = loadConfig();
+  const env = loadGbrainEnv();
+  const config = loadConfig(env);
   gatewayConfig = {
     embedding_model: config?.embedding_model,
     embedding_dimensions: config?.embedding_dimensions,
@@ -45,7 +46,7 @@ function configureFromEnv(): void {
     chat_fallback_chain: config?.chat_fallback_chain,
     base_urls: config?.provider_base_urls,
     provider_auth: config?.provider_auth,
-    env: { ...process.env },
+    env,
   };
   configureGateway(gatewayConfig);
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -76,7 +76,7 @@ export interface GBrainConfig {
  * Load config with credential precedence: env vars > config file.
  * Plugin config is handled by the plugin runtime injecting env vars.
  */
-export function loadConfig(): GBrainConfig | null {
+export function loadConfig(env: Record<string, string | undefined> = loadGbrainEnv()): GBrainConfig | null {
   let fileConfig: GBrainConfig | null = null;
   try {
     const raw = readFileSync(getConfigPath(), 'utf-8');
@@ -84,7 +84,7 @@ export function loadConfig(): GBrainConfig | null {
   } catch { /* no config file */ }
 
   // Try env vars
-  const dbUrl = process.env.GBRAIN_DATABASE_URL || process.env.DATABASE_URL;
+  const dbUrl = env.GBRAIN_DATABASE_URL || env.DATABASE_URL;
 
   if (!fileConfig && !dbUrl) return null;
 
@@ -97,27 +97,27 @@ export function loadConfig(): GBrainConfig | null {
     ...fileConfig,
     engine: inferredEngine,
     ...(dbUrl ? { database_url: dbUrl } : {}),
-    ...(process.env.OPENAI_API_KEY ? { openai_api_key: process.env.OPENAI_API_KEY } : {}),
-    ...(process.env.GBRAIN_EMBEDDING_MODEL ? { embedding_model: process.env.GBRAIN_EMBEDDING_MODEL } : {}),
+    ...(env.OPENAI_API_KEY ? { openai_api_key: env.OPENAI_API_KEY } : {}),
+    ...(env.GBRAIN_EMBEDDING_MODEL ? { embedding_model: env.GBRAIN_EMBEDDING_MODEL } : {}),
     ...(() => {
-      const raw = process.env.GBRAIN_EMBEDDING_DIMENSIONS;
+      const raw = env.GBRAIN_EMBEDDING_DIMENSIONS;
       if (!raw) return {};
       const value = Number(raw);
       return Number.isInteger(value) && value > 0 ? { embedding_dimensions: value } : {};
     })(),
-    ...(process.env.GBRAIN_EXPANSION_MODEL ? { expansion_model: process.env.GBRAIN_EXPANSION_MODEL } : {}),
-    ...(process.env.GBRAIN_CHAT_MODEL ? { chat_model: process.env.GBRAIN_CHAT_MODEL } : {}),
-    ...(process.env.GBRAIN_CHAT_FALLBACK_CHAIN
-      ? { chat_fallback_chain: process.env.GBRAIN_CHAT_FALLBACK_CHAIN.split(',').map(s => s.trim()).filter(Boolean) }
+    ...(env.GBRAIN_EXPANSION_MODEL ? { expansion_model: env.GBRAIN_EXPANSION_MODEL } : {}),
+    ...(env.GBRAIN_CHAT_MODEL ? { chat_model: env.GBRAIN_CHAT_MODEL } : {}),
+    ...(env.GBRAIN_CHAT_FALLBACK_CHAIN
+      ? { chat_fallback_chain: env.GBRAIN_CHAT_FALLBACK_CHAIN.split(',').map(s => s.trim()).filter(Boolean) }
       : {}),
   };
-  if (process.env.GBRAIN_OPENAI_AUTH_SOURCE === 'openclaw-codex' || process.env.GBRAIN_OPENAI_AUTH_SOURCE === 'openclaw-openai') {
+  if (env.GBRAIN_OPENAI_AUTH_SOURCE === 'openclaw-codex' || env.GBRAIN_OPENAI_AUTH_SOURCE === 'openclaw-openai') {
     merged.provider_auth = {
       ...(merged.provider_auth ?? {}),
       openai: {
-        prefer: process.env.GBRAIN_OPENAI_AUTH_SOURCE,
-        ...(process.env.GBRAIN_OPENAI_AUTH_PROFILE ? { profile: process.env.GBRAIN_OPENAI_AUTH_PROFILE } : {}),
-        ...(process.env.GBRAIN_OPENCLAW_AUTH_PATH ? { openclawAuthPath: process.env.GBRAIN_OPENCLAW_AUTH_PATH } : {}),
+        prefer: env.GBRAIN_OPENAI_AUTH_SOURCE,
+        ...(env.GBRAIN_OPENAI_AUTH_PROFILE ? { profile: env.GBRAIN_OPENAI_AUTH_PROFILE } : {}),
+        ...(env.GBRAIN_OPENCLAW_AUTH_PATH ? { openclawAuthPath: env.GBRAIN_OPENCLAW_AUTH_PATH } : {}),
       },
     };
   }
@@ -163,6 +163,73 @@ export function configDir(): string {
 
 export function configPath(): string {
   return join(configDir(), 'config.json');
+}
+
+export function gbrainEnvPath(env: Record<string, string | undefined> = process.env): string {
+  return env.GBRAIN_ENV_FILE || env.GBRAIN_ENV_PATH || join(configDir(), 'gbrain.env');
+}
+
+function parseEnvValue(value: string): string {
+  const raw = value.trim();
+  if (!raw) return '';
+  const quote = raw[0];
+  if (quote !== "'" && quote !== '"') return stripInlineComment(raw);
+
+  let out = '';
+  for (let i = 1; i < raw.length; i += 1) {
+    const char = raw[i];
+    if (char === quote) return out;
+    if (quote === '"' && char === '\\' && i + 1 < raw.length) {
+      const next = raw[i + 1];
+      if (next === 'n') out += '\n';
+      else if (next === 'r') out += '\r';
+      else if (next === 't') out += '\t';
+      else out += next;
+      i += 1;
+      continue;
+    }
+    out += char;
+  }
+  return out;
+}
+
+function stripInlineComment(raw: string): string {
+  for (let i = 0; i < raw.length; i += 1) {
+    if (raw[i] !== '#') continue;
+    const prev = raw[i - 1];
+    if (prev === ' ' || prev === '\t') return raw.slice(0, i).trimEnd();
+  }
+  return raw.trimEnd();
+}
+
+export function parseGbrainEnv(content: string): Record<string, string> {
+  const parsed: Record<string, string> = {};
+  for (const rawLine of String(content || '').split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const assignment = line.replace(/^export\s+/u, '');
+    const idx = assignment.indexOf('=');
+    if (idx <= 0) continue;
+    const key = assignment.slice(0, idx).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/u.test(key)) continue;
+    parsed[key] = parseEnvValue(assignment.slice(idx + 1));
+  }
+  return parsed;
+}
+
+export function loadGbrainEnv(env: Record<string, string | undefined> = process.env): Record<string, string | undefined> {
+  const merged: Record<string, string | undefined> = { ...env };
+  let parsed: Record<string, string>;
+  try {
+    parsed = parseGbrainEnv(readFileSync(gbrainEnvPath(env), 'utf-8'));
+  } catch {
+    return merged;
+  }
+  for (const [key, value] of Object.entries(parsed)) {
+    if (Object.hasOwn(merged, key)) continue;
+    merged[key] = value;
+  }
+  return merged;
 }
 
 /**

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -882,12 +882,12 @@ export class PGLiteEngine implements BrainEngine {
 
   async listStaleChunks(): Promise<StaleChunkRow[]> {
     const { rows } = await this.db.query(
-      `SELECT p.slug, cc.chunk_index, cc.chunk_text, cc.chunk_source,
+      `SELECT p.source_id, p.slug, cc.chunk_index, cc.chunk_text, cc.chunk_source,
               cc.model, cc.token_count
          FROM content_chunks cc
          JOIN pages p ON p.id = cc.page_id
         WHERE cc.embedding IS NULL
-        ORDER BY p.id, cc.chunk_index
+        ORDER BY p.source_id, p.id, cc.chunk_index
         LIMIT 100000`,
     );
     return rows as unknown as StaleChunkRow[];

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -897,12 +897,12 @@ export class PostgresEngine implements BrainEngine {
   async listStaleChunks(): Promise<StaleChunkRow[]> {
     const sql = this.sql;
     const rows = await sql`
-      SELECT p.slug, cc.chunk_index, cc.chunk_text, cc.chunk_source,
+      SELECT p.source_id, p.slug, cc.chunk_index, cc.chunk_text, cc.chunk_source,
              cc.model, cc.token_count
       FROM content_chunks cc
       JOIN pages p ON p.id = cc.page_id
       WHERE cc.embedding IS NULL
-      ORDER BY p.id, cc.chunk_index
+      ORDER BY p.source_id, p.id, cc.chunk_index
       LIMIT 100000
     `;
     return rows as unknown as StaleChunkRow[];

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -108,6 +108,7 @@ export interface Chunk {
  * rows) embedding bytes over the wire. See `embed --stale` egress fix.
  */
 export interface StaleChunkRow {
+  source_id: string;
   slug: string;
   chunk_index: number;
   chunk_text: string;

--- a/test/embed-stale-source.serial.test.ts
+++ b/test/embed-stale-source.serial.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, mock, test } from 'bun:test';
+import type { BrainEngine } from '../src/core/engine.ts';
+import type { Chunk } from '../src/core/types.ts';
+
+const embedBatchMock = mock(async (texts: string[]) => texts.map(() => new Float32Array([0.1, 0.2, 0.3])));
+
+mock.module('../src/core/embedding.ts', () => ({
+  embedBatch: embedBatchMock,
+}));
+
+describe('embed --stale source awareness', () => {
+  test('re-embeds stale chunks in their owning source', async () => {
+    const calls: Array<{ name: string; sourceId?: string }> = [];
+    const upserts: Array<{ sourceId?: string; embedding?: Float32Array }> = [];
+    const chunk: Chunk = {
+      id: 1,
+      page_id: 10,
+      chunk_index: 0,
+      chunk_text: 'Support KB text',
+      chunk_source: 'compiled_truth',
+      embedding: null,
+      model: 'voyage-4-large',
+      token_count: 4,
+      embedded_at: null,
+    };
+    const engine = {
+      countStaleChunks: async () => 1,
+      listStaleChunks: async () => [
+        {
+          source_id: 'openclaw-support-kb',
+          slug: 'docs/support',
+          chunk_index: 0,
+          chunk_text: 'Support KB text',
+          chunk_source: 'compiled_truth',
+          model: 'voyage-4-large',
+          token_count: 4,
+        },
+      ],
+      getChunks: async (_slug: string, opts?: { sourceId?: string }) => {
+        calls.push({ name: 'getChunks', sourceId: opts?.sourceId });
+        return opts?.sourceId === 'openclaw-support-kb' ? [chunk] : [];
+      },
+      upsertChunks: async (_slug: string, chunks, opts?: { sourceId?: string }) => {
+        calls.push({ name: 'upsertChunks', sourceId: opts?.sourceId });
+        upserts.push({ sourceId: opts?.sourceId, embedding: chunks[0]?.embedding });
+      },
+    } as Partial<BrainEngine> as BrainEngine;
+
+    const { runEmbedCore } = await import('../src/commands/embed.ts');
+    const result = await runEmbedCore(engine, { stale: true });
+
+    expect(result.embedded).toBe(1);
+    expect(calls).toEqual([
+      { name: 'getChunks', sourceId: 'openclaw-support-kb' },
+      { name: 'upsertChunks', sourceId: 'openclaw-support-kb' },
+    ]);
+    expect(upserts[0]?.embedding).toBeInstanceOf(Float32Array);
+  });
+});

--- a/test/gbrain-home-isolation.test.ts
+++ b/test/gbrain-home-isolation.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, test, expect } from 'bun:test';
-import { mkdtempSync, existsSync, readdirSync, statSync, rmSync } from 'fs';
+import { mkdtempSync, existsSync, readdirSync, statSync, rmSync, mkdirSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -89,6 +89,61 @@ describe('GBRAIN_HOME write-side isolation', () => {
       expect(loaded?.database_path).toBe(cfg.database_path);
     } finally {
       process.env.GBRAIN_HOME = ORIG_GBRAIN_HOME;
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('loadConfig reads local gbrain.env without mutating process env', async () => {
+    const tmp = fresh();
+    const saved = {
+      GBRAIN_HOME: process.env.GBRAIN_HOME,
+      VOYAGE_API_KEY: process.env.VOYAGE_API_KEY,
+      GBRAIN_EMBEDDING_MODEL: process.env.GBRAIN_EMBEDDING_MODEL,
+      GBRAIN_EMBEDDING_DIMENSIONS: process.env.GBRAIN_EMBEDDING_DIMENSIONS,
+    };
+    process.env.GBRAIN_HOME = tmp;
+    delete process.env.VOYAGE_API_KEY;
+    delete process.env.GBRAIN_EMBEDDING_MODEL;
+    delete process.env.GBRAIN_EMBEDDING_DIMENSIONS;
+    try {
+      const gbrainDir = join(tmp, '.gbrain');
+      mkdirSync(gbrainDir, { recursive: true });
+      writeFileSync(
+        join(gbrainDir, 'config.json'),
+        JSON.stringify({ engine: 'pglite', database_path: join(gbrainDir, 'brain.pglite') }) + '\n',
+      );
+      writeFileSync(
+        join(gbrainDir, 'gbrain.env'),
+        [
+          "# Local provider config",
+          "export VOYAGE_API_KEY='voyage-secret # kept'",
+          'GBRAIN_EMBEDDING_MODEL="voyage:voyage-4-large"',
+          'GBRAIN_EMBEDDING_DIMENSIONS=2048 # inline comment',
+          'BAD-NAME=ignored',
+          '',
+        ].join('\n'),
+      );
+
+      const { loadConfig, loadGbrainEnv } = await import('../src/core/config.ts');
+      const config = loadConfig();
+      const env = loadGbrainEnv();
+
+      expect(config?.embedding_model).toBe('voyage:voyage-4-large');
+      expect(config?.embedding_dimensions).toBe(2048);
+      expect(env.VOYAGE_API_KEY).toBe('voyage-secret # kept');
+      expect(env.GBRAIN_EMBEDDING_MODEL).toBe('voyage:voyage-4-large');
+      expect(env.GBRAIN_EMBEDDING_DIMENSIONS).toBe('2048');
+      expect(env['BAD-NAME']).toBeUndefined();
+      expect(process.env.VOYAGE_API_KEY).toBeUndefined();
+    } finally {
+      if (saved.GBRAIN_HOME === undefined) delete process.env.GBRAIN_HOME;
+      else process.env.GBRAIN_HOME = saved.GBRAIN_HOME;
+      if (saved.VOYAGE_API_KEY === undefined) delete process.env.VOYAGE_API_KEY;
+      else process.env.VOYAGE_API_KEY = saved.VOYAGE_API_KEY;
+      if (saved.GBRAIN_EMBEDDING_MODEL === undefined) delete process.env.GBRAIN_EMBEDDING_MODEL;
+      else process.env.GBRAIN_EMBEDDING_MODEL = saved.GBRAIN_EMBEDDING_MODEL;
+      if (saved.GBRAIN_EMBEDDING_DIMENSIONS === undefined) delete process.env.GBRAIN_EMBEDDING_DIMENSIONS;
+      else process.env.GBRAIN_EMBEDDING_DIMENSIONS = saved.GBRAIN_EMBEDDING_DIMENSIONS;
       rmSync(tmp, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Summary

Fixes two install-readiness bugs found while proving the OpenClaw Support KB + Voyage path end to end:

1. GBrain now loads its own local env file (`~/.gbrain/gbrain.env`, or `GBRAIN_ENV_FILE` / `GBRAIN_ENV_PATH`) when building provider config and AI gateway env snapshots.
2. `gbrain embed --stale` now carries `source_id` through the fast stale-chunk path, so non-default sources like `openclaw-support-kb` actually get their stale chunks repaired.

Closes #51.

## Why This Matters

The KB should not have a separate Voyage config. GBrain owns embedding/search, and the KB is just content. Before this PR, a machine could have a valid Voyage config in GBrain's local env file while direct agent commands still failed unless the shell manually sourced that file.

```mermaid
flowchart LR
  A["Agent or cron runs gbrain"] --> B["load ~/.gbrain/gbrain.env"]
  B --> C["loadConfig uses merged env"]
  C --> D["AI gateway gets same env snapshot"]
  D --> E["Voyage 4 Large 2048d works"]
```

The stale embed bug was a second layer: the optimized `embed --stale` query listed stale chunks globally, but grouped only by slug and then re-read chunks from `source_id=default`. For named sources, that meant Voyage calls could happen while the missing chunks stayed missing. This PR makes stale embedding operate on the real page identity: `(source_id, slug)`.

## Validation

- `bun test test/embed-stale-source.serial.test.ts test/gbrain-home-isolation.test.ts test/commands/providers.serial.test.ts test/pglite-engine.test.ts`
- `bun run verify`
- Live smoke with `VOYAGE_API_KEY` removed from shell:
  - `gbrain providers test --touchpoint embedding` -> 2048 dims, all probes green
  - `gbrain embed --stale` -> repaired 609 KB chunks, then next run returned 0 stale
  - `gbrain doctor --json` -> health score 100, embeddings 100% coverage, 0 missing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-source embedding handling to group and update content by source identity
  * Environment-file support and environment-aware config/gateway initialization

* **Bug Fixes**
  * Stale embeddings are now updated only within their designated source, preventing cross-source conflicts

* **Tests**
  * Added tests for multi-source embedding behavior and for environment-file parsing/isolation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->