### PR TITLE
Fix OpenClaw plugin Bun PATH for source installs

### DIFF
--- a/plugins/openclaw-gbrain/README.md
+++ b/plugins/openclaw-gbrain/README.md
@@ -79,6 +79,12 @@ not returned by tools or the extraction route, so provider keys such as
 `VOYAGE_API_KEY` can live in the normal GBrain env file without being copied into
 OpenClaw's global launch environment.
 
+The plugin prepends `$HOME/.bun/bin` to spawned command PATH because macOS
+LaunchAgents often start with a minimal PATH. Use the source-linked CLI from
+`bun link` for PGLite installs. Do not point `gbrainBin` at a
+`bun build --compile` binary for local PGLite brains; compiled Bun binaries do
+not bundle PGLite's `pglite.data` runtime asset.
+
 Extraction is intentionally conservative by default: one active extraction at a
 time, up to eight queued requests, and a 30s queue wait. Increase those values
 only after the local OpenClaw/Codex runtime is proven to tolerate the extra load.

--- a/plugins/openclaw-gbrain/index.js
+++ b/plugins/openclaw-gbrain/index.js
@@ -114,11 +114,22 @@ function unquoteEnvValue(value) {
 
 function commandEnv(config) {
   const fileEnv = readEnvFile(config.envFile);
+  const bunBin = join(homedir(), ".bun", "bin");
+  const basePath = fileEnv.PATH ?? process.env.PATH ?? "";
   return {
     ...process.env,
     ...fileEnv,
-    PATH: fileEnv.PATH ?? process.env.PATH ?? "",
+    BUN_INSTALL: fileEnv.BUN_INSTALL ?? process.env.BUN_INSTALL ?? join(homedir(), ".bun"),
+    PATH: prependPathEntry(basePath, bunBin),
   };
+}
+
+function prependPathEntry(pathValue, entry) {
+  const parts = String(pathValue || "")
+    .split(":")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  return [entry, ...parts.filter((part) => part !== entry)].join(":");
 }
 
 function runCommand(command, args, config, options = {}) {

--- a/test/install-contract.test.ts
+++ b/test/install-contract.test.ts
@@ -77,4 +77,17 @@ describe('Eva Brain install contract', () => {
     expect(plugin).toContain('resolved.slice("openai-codex/".length).trim() === ""');
     expect(plugin).toContain('invalid_model');
   });
+
+  test('OpenClaw plugin keeps source-linked Bun CLI usable under LaunchAgents', () => {
+    const plugin = readFileSync(join(root, 'plugins/openclaw-gbrain/index.js'), 'utf8');
+    const readme = readFileSync(join(root, 'plugins/openclaw-gbrain/README.md'), 'utf8');
+
+    expect(plugin).toContain('join(homedir(), ".bun", "bin")');
+    expect(plugin).toContain('prependPathEntry(basePath, bunBin)');
+    expect(plugin).toContain('BUN_INSTALL');
+    expect(readme).toContain('LaunchAgents often start with a minimal PATH');
+    expect(readme).toContain('Use the source-linked CLI from');
+    expect(readme).toContain('Do not point `gbrainBin` at a');
+    expect(readme).toContain("PGLite's `pglite.data`");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #55.

Post-merge local smoke found that the merged source install works, but the OpenClaw LaunchAgent environment can be too small for a `bun link`-installed `gbrain` shim. The shim uses `#!/usr/bin/env bun`; if `$HOME/.bun/bin` is missing from PATH, plugin tools can fail even though the repo installed correctly.

This PR makes the OpenClaw plugin prepend `$HOME/.bun/bin` to spawned `gbrain`/`openclaw` command PATH and sets a default `BUN_INSTALL`. It also documents the runtime boundary: use the source-linked CLI for PGLite installs, not the compiled Bun binary, because compiled binaries do not bundle PGLite's `pglite.data` asset.

## Validation

- `bun test test/install-contract.test.ts --timeout=120000`
- `bun run verify`

## Local Smoke That Triggered This

- Clean merged clone at `fb7b35b93425d8ea3c2c62bf86cbb1d9a38a9d80` passed init/import/search/doctor with `bun run src/cli.ts`.
- Compiled extension binary failed PGLite init with missing `/$bunfs/root/pglite.data`.
- Source-wrapper/OpenClaw extension path passed temp `GBRAIN_HOME` init, import, search, and doctor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added configuration guidance for macOS LaunchAgent environments and PGLite setups
  * Added warnings about compiled Bun binary constraints

* **Bug Fixes**
  * Enhanced PATH resolution in subprocess environments for improved compatibility

* **Tests**
  * Added contract test verifying plugin functionality in minimal PATH environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->