### PR TITLE
Fix health embedding coverage truth source

### DIFF
--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -333,13 +333,13 @@ export interface BrainEngine {
   upsertChunks(slug: string, chunks: ChunkInput[], opts?: { sourceId?: string }): Promise<void>;
   getChunks(slug: string, opts?: { sourceId?: string }): Promise<Chunk[]>;
   /**
-   * Count chunks across the entire brain where embedded_at IS NULL.
+   * Count text chunks across the entire brain where embedding IS NULL.
    * Pre-flight short-circuit for `embed --stale` so a 100%-embedded brain
    * does no further work after a single SELECT count(*) (~50 bytes wire).
    */
   countStaleChunks(opts?: { sourceId?: string }): Promise<number>;
   /**
-   * Return every chunk where embedded_at IS NULL, with the metadata needed
+   * Return every text chunk where embedding IS NULL, with the metadata needed
    * to call embedBatch + upsertChunks. The `embedding` column is omitted
    * by design — stale rows have NULL embeddings, so shipping them wastes
    * wire bytes for no gain. Caller groups by slug, embeds, and re-upserts.

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -1947,11 +1947,14 @@ export class PGLiteEngine implements BrainEngine {
     const { rows: [h] } = await this.db.query(`
       WITH entity_pages AS (
         SELECT id, slug FROM pages WHERE type IN ('person', 'company')
+      ),
+      text_chunks AS (
+        SELECT * FROM content_chunks WHERE COALESCE(modality, 'text') = 'text'
       )
       SELECT
         (SELECT count(*) FROM pages) as page_count,
-        (SELECT count(*) FROM content_chunks WHERE embedded_at IS NOT NULL)::float /
-          GREATEST((SELECT count(*) FROM content_chunks), 1)::float as embed_coverage,
+        (SELECT count(*) FROM text_chunks WHERE embedding IS NOT NULL)::float /
+          GREATEST((SELECT count(*) FROM text_chunks), 1)::float as embed_coverage,
         (SELECT count(*) FROM pages p
          WHERE p.updated_at < (SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id)
         ) as stale_pages,
@@ -1964,7 +1967,7 @@ export class PGLiteEngine implements BrainEngine {
         (SELECT count(*) FROM links l
          WHERE NOT EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id)
         ) as dead_links,
-        (SELECT count(*) FROM content_chunks WHERE embedded_at IS NULL) as missing_embeddings,
+        (SELECT count(*) FROM text_chunks WHERE embedding IS NULL) as missing_embeddings,
         (SELECT count(*) FROM links) as link_count,
         (SELECT count(DISTINCT page_id) FROM timeline_entries) as pages_with_timeline,
         (SELECT count(*) FROM entity_pages) as entity_page_count,

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1981,11 +1981,14 @@ export class PostgresEngine implements BrainEngine {
     const [h] = await sql`
       WITH entity_pages AS (
         SELECT id, slug FROM pages WHERE type IN ('person', 'company')
+      ),
+      text_chunks AS (
+        SELECT * FROM content_chunks WHERE COALESCE(modality, 'text') = 'text'
       )
       SELECT
         (SELECT count(*) FROM pages) as page_count,
-        (SELECT count(*) FROM content_chunks WHERE embedded_at IS NOT NULL)::float /
-          GREATEST((SELECT count(*) FROM content_chunks), 1)::float as embed_coverage,
+        (SELECT count(*) FROM text_chunks WHERE embedding IS NOT NULL)::float /
+          GREATEST((SELECT count(*) FROM text_chunks), 1)::float as embed_coverage,
         (SELECT count(*) FROM pages p
          WHERE p.updated_at < (SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id)
         ) as stale_pages,
@@ -1996,7 +1999,7 @@ export class PostgresEngine implements BrainEngine {
         (SELECT count(*) FROM links l
          WHERE NOT EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id)
         ) as dead_links,
-        (SELECT count(*) FROM content_chunks WHERE embedded_at IS NULL) as missing_embeddings,
+        (SELECT count(*) FROM text_chunks WHERE embedding IS NULL) as missing_embeddings,
         (SELECT count(*) FROM links) as link_count,
         (SELECT count(DISTINCT page_id) FROM timeline_entries) as pages_with_timeline,
         (SELECT count(*) FROM entity_pages) as entity_page_count,

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -819,6 +819,28 @@ describe('PGLiteEngine: Stats & Health', () => {
     expect(health.missing_embeddings).toBe(1); // chunk has no embedding
     expect(health.embed_coverage).toBe(0);
   });
+
+  test('getHealth treats embedding presence, not embedded_at timestamp, as coverage truth', async () => {
+    await truncateAll();
+    await engine.putPage('test/embedded-no-timestamp', testPage);
+    await engine.upsertChunks('test/embedded-no-timestamp', [
+      {
+        chunk_index: 0,
+        chunk_text: 'chunk with vector but missing timestamp',
+        chunk_source: 'compiled_truth',
+        embedding: new Float32Array(1536).fill(0.01),
+      },
+    ]);
+    await (engine as any).db.query(
+      `UPDATE content_chunks SET embedded_at = NULL WHERE chunk_text = $1`,
+      ['chunk with vector but missing timestamp'],
+    );
+
+    const health = await engine.getHealth();
+    expect(health.missing_embeddings).toBe(0);
+    expect(health.embed_coverage).toBe(1);
+  });
+
 });
 
 // ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #59.

This fixes the mismatch where `gbrain doctor` and `gbrain embed --stale` treated text embedding presence as the source of truth, but lightweight `gbrain health` still used `embedded_at`. A chunk can have a valid vector with a missing timestamp, so `health` could report false missing embeddings and push agents toward an unnecessary embedding run.

## What Changed

- PGLite `getHealth()` now computes text embedding coverage from `embedding IS NULL/NOT NULL`.
- Postgres `getHealth()` uses the same truth source.
- Non-text/image chunks are excluded from text embedding coverage.
- Added a regression test for a chunk with a vector and `embedded_at = NULL`.
- Updated the engine comments to match the actual stale-embedding contract.

## Local Validation

```bash
bun test test/pglite-engine.test.ts -t "embedding presence"
bun test test/pglite-engine.test.ts test/embed.serial.test.ts
bun run typecheck
bun run verify
git diff --check HEAD~1..HEAD
/Users/lume/.bun/bin/gbrain embed --stale
/Users/lume/.bun/bin/gbrain health
/Users/lume/.bun/bin/gbrain doctor --json
```

Observed local canary after repair:

```text
gbrain health -> Health score: 10/10, Embed coverage: 100.0%, Missing embeddings: 0
gbrain doctor --json -> health_score 100, embeddings 100% coverage, 0 missing, Voyage 2048 DB aligned
```