### PR TITLE
Harden OpenClaw extraction plugin boundary

### DIFF
--- a/plugins/openclaw-gbrain/README.md
+++ b/plugins/openclaw-gbrain/README.md
@@ -66,7 +66,8 @@ needed:
           "maxConcurrentExtractions": 1,
           "extractionQueueLimit": 8,
           "extractionQueueTimeoutMs": 30000,
-          "minExtractionIntervalMs": 0
+          "minExtractionIntervalMs": 0,
+          "maxExtractionFileBytes": 8000000
         }
       }
     }
@@ -88,6 +89,8 @@ not bundle PGLite's `pglite.data` runtime asset.
 Extraction is intentionally conservative by default: one active extraction at a
 time, up to eight queued requests, and a 30s queue wait. Increase those values
 only after the local OpenClaw/Codex runtime is proven to tolerate the extra load.
+The route also rejects decoded file payloads larger than 8,000,000 bytes by
+default; the hard plugin cap is 20 MiB.
 
 ## Smoke
 

--- a/plugins/openclaw-gbrain/index.js
+++ b/plugins/openclaw-gbrain/index.js
@@ -14,11 +14,14 @@ const DEFAULT_MAX_CONCURRENT_EXTRACTIONS = 1;
 const DEFAULT_EXTRACTION_QUEUE_LIMIT = 8;
 const DEFAULT_EXTRACTION_QUEUE_TIMEOUT_MS = 30_000;
 const DEFAULT_MIN_EXTRACTION_INTERVAL_MS = 0;
+const DEFAULT_MAX_EXTRACTION_FILE_BYTES = 8_000_000;
 const GBRAIN_ROUTE_PATH = "/plugins/gbrain/extract";
-const MAX_BODY_BYTES = 12 * 1024 * 1024;
 const MAX_TIMEOUT_MS = 300_000;
 const MAX_EXTRACTION_QUEUE_LIMIT = 100;
 const MAX_MIN_EXTRACTION_INTERVAL_MS = 60_000;
+const MAX_EXTRACTION_FILE_BYTES = 20 * 1024 * 1024;
+const DEFAULT_MAX_BODY_BYTES = 12 * 1024 * 1024;
+const MAX_BODY_BYTES = Math.ceil((MAX_EXTRACTION_FILE_BYTES * 4) / 3) + 512_000;
 
 let activeExtractions = 0;
 const extractionQueue = [];
@@ -57,6 +60,12 @@ function readConfig(pluginConfig) {
       DEFAULT_MIN_EXTRACTION_INTERVAL_MS,
       0,
       MAX_MIN_EXTRACTION_INTERVAL_MS,
+    ),
+    maxExtractionFileBytes: readBoundedInteger(
+      cfg.maxExtractionFileBytes,
+      DEFAULT_MAX_EXTRACTION_FILE_BYTES,
+      1,
+      MAX_EXTRACTION_FILE_BYTES,
     ),
   };
 }
@@ -298,13 +307,13 @@ async function handleExtractionRoute(config, req, res) {
   let tempDir;
   let releaseSlot;
   try {
-    const body = await readJsonBody(req, MAX_BODY_BYTES);
+    const body = await readJsonBody(req, requestBodyLimitBytes(config.maxExtractionFileBytes));
     const request = readExtractionRequest(body);
     const kind = normalizeMediaKind(request.kind);
     const sourceRef = normalizeRequiredString(request.sourceRef, "sourceRef");
     const title = normalizeOptionalString(request.title);
     const text = normalizeOptionalString(request.text);
-    const image = readImageInput(request);
+    const image = readImageInput(request, config);
     if (!text && !image) {
       throw new RequestError(400, "missing_content", "Provide text or file.base64.");
     }
@@ -534,14 +543,46 @@ function readExtractionRequest(value) {
   return value;
 }
 
-function readImageInput(request) {
+function readImageInput(request, config) {
   const file = isRecord(request.file) ? request.file : undefined;
   const base64 = normalizeOptionalString(file?.base64);
   if (!base64) return undefined;
+  const normalizedBase64 = normalizeBase64Payload(base64);
+  const decodedBytes = decodedBase64ByteLength(normalizedBase64);
+  if (decodedBytes > config.maxExtractionFileBytes) {
+    throw new RequestError(
+      413,
+      "file_too_large",
+      `GBrain extraction file is too large (${decodedBytes} bytes, max ${config.maxExtractionFileBytes}).`,
+    );
+  }
   return {
-    base64,
+    base64: normalizedBase64,
     name: sanitizeFileName(normalizeOptionalString(file.name) ?? "image.png"),
+    decodedBytes,
   };
+}
+
+function requestBodyLimitBytes(maxExtractionFileBytes) {
+  return Math.min(
+    MAX_BODY_BYTES,
+    Math.max(DEFAULT_MAX_BODY_BYTES, Math.ceil((maxExtractionFileBytes * 4) / 3) + 512_000),
+  );
+}
+
+function normalizeBase64Payload(value) {
+  const trimmed = value.trim();
+  const dataUrl = trimmed.match(/^data:[^,]+;base64,(.+)$/su);
+  const compact = (dataUrl ? dataUrl[1] : trimmed).replace(/\s+/gu, "");
+  if (!compact || compact.length % 4 === 1 || !/^[A-Za-z0-9+/]*={0,2}$/u.test(compact)) {
+    throw new RequestError(400, "invalid_file_base64", "file.base64 must be valid base64.");
+  }
+  return compact;
+}
+
+function decodedBase64ByteLength(base64) {
+  const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
+  return Math.floor((base64.length * 3) / 4) - padding;
 }
 
 function sanitizeFileName(value) {

--- a/plugins/openclaw-gbrain/openclaw.plugin.json
+++ b/plugins/openclaw-gbrain/openclaw.plugin.json
@@ -55,6 +55,10 @@
       "minExtractionIntervalMs": {
         "type": "number",
         "description": "Minimum delay between extraction starts. Defaults to 0."
+      },
+      "maxExtractionFileBytes": {
+        "type": "number",
+        "description": "Maximum decoded bytes accepted for a file passed to /plugins/gbrain/extract. Defaults to 8000000 and is capped at 20MiB."
       }
     }
   }

--- a/test/openclaw-gbrain-plugin-contract.test.ts
+++ b/test/openclaw-gbrain-plugin-contract.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const repoRoot = new URL('..', import.meta.url).pathname;
+const pluginSource = readFileSync(join(repoRoot, 'plugins/openclaw-gbrain/index.js'), 'utf-8');
+const pluginReadme = readFileSync(join(repoRoot, 'plugins/openclaw-gbrain/README.md'), 'utf-8');
+const manifest = JSON.parse(
+  readFileSync(join(repoRoot, 'plugins/openclaw-gbrain/openclaw.plugin.json'), 'utf-8'),
+);
+
+describe('OpenClaw GBrain plugin boundary', () => {
+  test('owns the OAuth-backed extraction route instead of putting it in GBrain core', () => {
+    expect(pluginSource).toContain('GBRAIN_ROUTE_PATH = "/plugins/gbrain/extract"');
+    expect(pluginSource).toContain('api.registerHttpRoute');
+    expect(pluginSource).toContain('auth: "gateway"');
+    expect(pluginSource).toContain('protocol: "gbrain.media-extraction.v1"');
+    expect(pluginSource).toContain('provider: "openai-codex"');
+  });
+
+  test('keeps extraction pressure controls in the plugin config contract', () => {
+    const props = manifest.configSchema.properties;
+    expect(props.maxConcurrentExtractions).toBeTruthy();
+    expect(props.extractionQueueLimit).toBeTruthy();
+    expect(props.extractionQueueTimeoutMs).toBeTruthy();
+    expect(props.minExtractionIntervalMs).toBeTruthy();
+    expect(props.maxExtractionFileBytes).toBeTruthy();
+
+    expect(pluginSource).toContain('DEFAULT_MAX_CONCURRENT_EXTRACTIONS = 1');
+    expect(pluginSource).toContain('DEFAULT_EXTRACTION_QUEUE_LIMIT = 8');
+    expect(pluginSource).toContain('DEFAULT_MAX_EXTRACTION_FILE_BYTES = 8_000_000');
+    expect(pluginReadme).toContain('"maxExtractionFileBytes": 8000000');
+  });
+
+  test('rejects oversized or malformed file payloads before temp files or model calls', () => {
+    expect(pluginSource).toContain('decodedBase64ByteLength');
+    expect(pluginSource).toContain('normalizeBase64Payload');
+    expect(pluginSource).toContain('file_too_large');
+    expect(pluginSource).toContain('invalid_file_base64');
+    expect(pluginSource.indexOf('readImageInput(request, config)')).toBeGreaterThan(-1);
+    expect(pluginSource.indexOf('await writeFile(imagePath')).toBeGreaterThan(
+      pluginSource.indexOf('readImageInput(request, config)'),
+    );
+  });
+
+  test('does not construct model API-key payload fields in the extraction route', () => {
+    expect(pluginSource).not.toContain('apiKey');
+    expect(pluginSource).not.toContain('OPENAI_API_KEY');
+    expect(pluginSource).not.toContain('refreshToken');
+    expect(pluginSource).not.toContain('accessToken');
+  });
+});


### PR DESCRIPTION
Closes #65.

## Summary

This is the thin-fork plugin-boundary slice stacked on PR #64.

It keeps Eva-specific extraction policy inside `plugins/openclaw-gbrain` instead of adding more permanent media/search/database behavior to GBrain core.

## What Changed

- Adds `maxExtractionFileBytes` to the OpenClaw plugin config schema.
- Enforces decoded `file.base64` size inside `/plugins/gbrain/extract` before writing temp files or calling the OpenClaw model runner.
- Normalizes raw base64 and `data:*;base64,...` payloads while rejecting malformed base64 with a controlled `invalid_file_base64` error.
- Keeps the conservative default at 8,000,000 decoded bytes with a hard plugin cap of 20 MiB.
- Documents the new extraction file-size policy next to the existing concurrency, queue, timeout, and interval controls.
- Adds contract coverage for the plugin route, gateway auth, queue/rate policy, file-size policy, and no model API-key payload fields.

## Thin-Fork Boundary

GBrain core still only sees normalized content/evidence and upstream-native pages/files/chunks. The OpenClaw plugin remains the owner of OAuth-backed extraction, runtime pressure controls, and host-specific route behavior.

## Validation

- `git diff --check` - passed
- `git diff --cached --check` - passed
- `bun test --timeout=60000 test/openclaw-gbrain-plugin-contract.test.ts test/codex-extraction-client.test.ts test/media-ingest-openclaw.serial.test.ts test/media-cli-smoke.test.ts` - 16 pass, 0 fail
- `bun run verify` - passed, including admin build and `tsc --noEmit`

## Stack Note

Base is `eva/merge-upstream-v0.30-scorecards` because this PR follows the catch-up sequence:

1. #62: v0.29.2 catch-up
2. #64: v0.30 scorecards
3. This PR: OpenClaw plugin extraction boundary
