### PR TITLE
Clarify media thin-fork adapter boundary

### DIFF
--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -93,6 +93,14 @@ The plugin provides:
 - `gbrain_query`
 - `/plugins/gbrain/extract` for OAuth-backed extraction through OpenClaw/Codex
 
+Media boundary: upstream GBrain owns native image indexing through image pages,
+file records, multimodal embeddings, OCR, and `query --image`. Eva's OpenClaw
+plugin owns OAuth-backed enrichment/extraction and returns
+`gbrain.media-extraction.v1` as an adapter payload. The `import-media` and
+`ingest-media --extract openclaw` commands are transitional compatibility paths
+for turning that payload into searchable pages while the plugin boundary
+continues to shrink toward upstream-native writes.
+
 If OpenClaw is not installed, skip this step and keep the CLI/MCP path.
 
 ## Step 3.6: Install The OpenClaw Support KB

--- a/docs/designs/MEDIA_EVIDENCE_ARCHITECTURE.md
+++ b/docs/designs/MEDIA_EVIDENCE_ARCHITECTURE.md
@@ -1,10 +1,10 @@
 # Media Evidence Architecture
 
-Status: Draft upstream architecture note
+Status: Draft upstream architecture note, kept as an adapter vocabulary
 
 Audience: downstream implementers and upstream GBrain maintainers
 
-Updated: 2026-05-04
+Updated: 2026-05-08
 
 ## Why This Exists
 
@@ -18,7 +18,13 @@ This document frames that gap in upstream-friendly terms:
 - **media resolvers** as the extraction boundary
 - **match reasons** as the retrieval explanation surface
 
-The intent is to let a downstream fork ship a practical text-backed MVP now without locking upstream into fork-local branding, storage choices, or provider choices.
+The intent is to let a downstream fork ship a practical OpenClaw extraction
+adapter now without locking upstream into fork-local branding, storage choices,
+or provider choices. Upstream GBrain's native image pages, file records,
+multimodal embeddings, OCR, and image-aware query behavior are the canonical
+long-term storage and retrieval path. `gbrain.media-extraction.v1` is the
+interchange payload an adapter can hand to GBrain, not a replacement for
+upstream-native media primitives.
 
 ## Problem Statement
 
@@ -54,9 +60,10 @@ Examples:
 - a local video file
 - a hosted YouTube URL once normalized into a tracked source object
 
-Current runtime contract: `gbrain.media-extraction.v1`.
+Current adapter interchange contract: `gbrain.media-extraction.v1`.
 
-The shipped text-backed MVP accepts normalized extraction payloads with these fields:
+The transitional OpenClaw adapter accepts normalized extraction payloads with
+these fields:
 
 ```ts
 interface MediaExtraction {

--- a/docs/guides/content-media.md
+++ b/docs/guides/content-media.md
@@ -1,8 +1,21 @@
 # Content and Media Ingestion
 
-## Current Shipping Boundary
+## Thin-Fork Boundary
 
-This fork currently ships a media evidence path:
+Upstream GBrain owns the long-term media core: native image pages, file
+records, multimodal embeddings, OCR, and image-aware query behavior. Eva Brain
+should use those primitives rather than keeping a separate fork-local media
+storage model.
+
+Eva's OpenClaw-specific value lives at the adapter boundary:
+
+- `/plugins/gbrain/extract` performs OAuth-backed extraction through the
+  OpenClaw/Codex runtime
+- the plugin returns `gbrain.media-extraction.v1`
+- GBrain core imports normalized content into pages, chunks, files, and raw
+  data
+
+The fork currently keeps these transitional compatibility commands:
 
 - normalized media evidence JSON can be imported with `gbrain import-media`
 - text-backed extraction can be bridged through `gbrain ingest-media --extract openclaw`
@@ -14,6 +27,10 @@ The `--extract openclaw` adapter prefers `GBRAIN_OPENCLAW_GATEWAY_URL` or
 `/plugins/gbrain/extract` and supports text plus the current image MVP. The
 `GBRAIN_OPENCLAW_COMPLETION_COMMAND` fallback remains text-only and is meant for
 local host adapters that cannot accept file media.
+
+Do not treat `import-media` / `ingest-media` as a permanent competing GBrain
+media subsystem. They are bridge commands until the OpenClaw plugin can write
+the upstream-native media representation directly.
 
 Direct binary video/audio/PDF understanding is the next adapter milestone. Keep
 binary extraction behind host, resolver, or provider adapters; do not present it

--- a/docs/guides/media-evidence.md
+++ b/docs/guides/media-evidence.md
@@ -4,15 +4,33 @@
 
 Make screenshots, PDFs, audio, and video searchable in GBrain through canonical media artifacts, resolver-based extraction, and evidence-backed match reasons.
 
-## Current Shipping Boundary
+## Thin-Fork Boundary
 
-This fork's current MVP is **text-backed media evidence**:
+Eva Brain should not grow a permanent competing media subsystem inside GBrain
+core. Upstream GBrain owns native media storage and retrieval primitives:
+image pages, the `files` table, multimodal embeddings, OCR, and image-aware
+query surfaces.
+
+Eva's durable responsibility is the OpenClaw adapter layer:
+
+- the OpenClaw plugin performs OAuth-backed extraction/enrichment
+- the adapter interchange payload is `gbrain.media-extraction.v1`
+- core GBrain receives normalized content, files, pages, chunks, and raw data
+
+The current fork-local MVP remains available as **transitional compatibility**:
 
 - `import-media` imports normalized evidence JSON and materializes it into normal pages, chunks, and raw data.
-- `ingest-media --extract openclaw` is a text extraction bridge for text-backed inputs and host-provided extraction output.
+- `ingest-media --extract openclaw` calls the OpenClaw plugin extraction route and imports the returned evidence.
 - Search can find media-derived OCR, captions, transcripts, summaries, tags, and match reasons once they are present in the normalized payload.
 
-This MVP does not claim direct binary image/video understanding inside core GBrain. Native image, video, audio, and frame extraction should live behind resolver or adapter boundaries so the upstream core stays provider-neutral.
+Treat those commands as bridge commands while the OpenClaw plugin learns to
+write upstream-native image pages/files/evidence directly. They should not be
+used as evidence that Eva core owns a separate long-term media model.
+
+This MVP does not claim direct binary video/audio/PDF understanding inside core
+GBrain. Native image indexing should follow upstream GBrain primitives; binary
+video/audio/PDF understanding should stay behind host, resolver, or provider
+adapters until it is live-smoked end to end.
 
 ## What the User Gets
 
@@ -46,17 +64,17 @@ The explanation shown to the user for why a result matched.
 
 ```text
 file or URL
-  -> media artifact
-  -> media segments
-  -> media resolvers or external extraction adapters
-  -> normalized media evidence JSON
-  -> searchable page/chunk materialization
-  -> result card with match reason
+  -> upstream GBrain file/image page when native support exists
+  -> OpenClaw extraction adapter when OAuth-backed enrichment is needed
+  -> gbrain.media-extraction.v1 interchange JSON
+  -> upstream-native page/file/chunk/raw-data writes
+  -> search result with provenance or match reason
 ```
 
 ## Fast Fork-Local MVP
 
-If you need user value immediately, keep it simple:
+If you need user value immediately through the transitional commands, keep it
+simple:
 
 1. Preserve the original binary or URL outside the normalized evidence payload.
 2. Create a normal page for the media item.
@@ -64,7 +82,9 @@ If you need user value immediately, keep it simple:
 4. Materialize extracted text into searchable content.
 5. Return media-aware results with a locator and match reason when available.
 
-This is intentionally pragmatic. It does not require a new vector backend or a full schema redesign.
+This is intentionally pragmatic. It does not require a new vector backend or a
+full schema redesign, and it should shrink as upstream native media support
+covers more of the path.
 
 ## Upstream-Friendly Seam
 

--- a/docs/guides/provider-install-matrix.md
+++ b/docs/guides/provider-install-matrix.md
@@ -152,22 +152,26 @@ Do not reuse a 1536d brain and expect the dimension mismatch to self-heal.
 If gbrain receives embeddings whose length does not match the configured dimension, it fails closed with an embedding-dimension error.
 That is expected and correct.
 
-## Host OAuth adapter for extraction
+## OpenClaw OAuth adapter for extraction
 
-This part is a **host-side dependency**.
+This part is a **host-side plugin dependency**, not a GBrain core embedding
+dependency.
 
 What we can safely document here today:
 - the fork's fresh 2048d install path is independent of host OAuth
-- the durable host OAuth auth propagation work is tracked in the downstream adapter issue
-- today's media support is text-backed normalized evidence import/search
-- production extraction that relies on host-managed OAuth should be considered dependent on a rebuilt, live-smoked adapter PR
+- the OpenClaw plugin exposes `/plugins/gbrain/extract`
+- the plugin routes extraction through OpenClaw's logged-in Codex runtime
+- the plugin owns extraction concurrency, queue, timeout, interval, and file-size policy
+- today's adapter payload is `gbrain.media-extraction.v1`
+- upstream GBrain native image pages/files/multimodal embeddings remain the canonical long-term media storage and indexing path
+- `import-media` and `ingest-media --extract openclaw` are transitional compatibility commands for materializing adapter output into searchable pages
 
 ### Recommended integrated rollout
 
 1. complete the fresh 2048d brain install first
 2. verify it with `gbrain doctor --json` and `gbrain stats`
-3. separately complete the host OAuth adapter/auth flow
-4. verify extraction on the host side
+3. install and enable `plugins/openclaw-gbrain`
+4. verify extraction on the host side through `/plugins/gbrain/extract`
 5. only then start customer imports / syncs
 
 ### Verification expectation for the OAuth half
@@ -177,10 +181,10 @@ Because the auth adapter is host-side, the verification should also be host-side
 - the extraction command/path should stop failing on missing auth
 - no secret values should be printed during verification
 
-Until the downstream adapter issue is proven with a live host runtime smoke, the safe fallback is:
+Until a live host runtime smoke has passed on the target machine, the safe fallback is:
 - use the documented 2048d embedding provider
 - use normalized media evidence JSON or text-backed extraction paths where applicable
-- do not claim fully supported no-extra-key host-managed OAuth extraction yet
+- do not claim binary video/audio/PDF understanding beyond the provider paths actually smoke-tested
 
 ## Post-init verification
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1434,6 +1434,14 @@ The plugin provides:
 - `gbrain_query`
 - `/plugins/gbrain/extract` for OAuth-backed extraction through OpenClaw/Codex
 
+Media boundary: upstream GBrain owns native image indexing through image pages,
+file records, multimodal embeddings, OCR, and `query --image`. Eva's OpenClaw
+plugin owns OAuth-backed enrichment/extraction and returns
+`gbrain.media-extraction.v1` as an adapter payload. The `import-media` and
+`ingest-media --extract openclaw` commands are transitional compatibility paths
+for turning that payload into searchable pages while the plugin boundary
+continues to shrink toward upstream-native writes.
+
 If OpenClaw is not installed, skip this step and keep the CLI/MCP path.
 
 ## Step 3.6: Install The OpenClaw Support KB


### PR DESCRIPTION
Closes #67.

## Summary

This docs-only PR makes the thin-fork media direction explicit.

Eva should not present `import-media` / `ingest-media --extract openclaw` as a permanent fork-local media subsystem. Upstream GBrain owns native image pages, file records, multimodal embeddings, OCR, and image-aware query behavior. Eva owns the OpenClaw OAuth extraction adapter and the `gbrain.media-extraction.v1` interchange payload.

## What Changed

- Updates `docs/guides/media-evidence.md` to describe the OpenClaw media payload as a transitional adapter contract.
- Updates `docs/guides/content-media.md` to clarify that the bridge commands are compatibility paths until the plugin can write upstream-native media records directly.
- Updates `docs/designs/MEDIA_EVIDENCE_ARCHITECTURE.md` so the architecture note is framed as adapter vocabulary, not a replacement storage model.
- Updates `INSTALL_FOR_AGENTS.md` and `docs/guides/provider-install-matrix.md` to explain the split between upstream-native media indexing and OpenClaw OAuth extraction.

## Validation

- `git diff --check` - passed
- `git diff --cached --check` - passed
- `bun test --timeout=60000 test/install-contract.test.ts test/openclaw-gbrain-plugin-contract.test.ts` - 12 pass, 0 fail
- `bun run verify` - passed, including admin build and `tsc --noEmit`

## Stack Note

Base is `eva/plugin-extraction-boundary` because this follows the approved thin-fork sequence:

1. #62: v0.29.2 catch-up
2. #64: v0.30 scorecards
3. #66: plugin extraction boundary
4. This PR: media docs de-duplication / thin-fork boundary
