### PR TITLE
fix: make /plugins/gbrain/extract the only default OAuth route

### DIFF
--- a/docs/guides/content-media.md
+++ b/docs/guides/content-media.md
@@ -26,7 +26,9 @@ The `--extract openclaw` adapter prefers `GBRAIN_OPENCLAW_GATEWAY_URL` or
 `OPENCLAW_GATEWAY_URL`, which calls OpenClaw's OAuth-backed Codex runtime through
 `/plugins/gbrain/extract` and supports text plus the current image MVP. The
 `GBRAIN_OPENCLAW_COMPLETION_COMMAND` fallback remains text-only and is meant for
-local host adapters that cannot accept file media.
+local host adapters that cannot accept file media. `GBRAIN_OPENCLAW_COMPLETION_PATH`
+is now legacy opt-in only for older hosts that still expose `/plugins/gbrain/complete`;
+the default repo and live install path is `/plugins/gbrain/extract`.
 
 Do not treat `import-media` / `ingest-media` as a permanent competing GBrain
 media subsystem. They are bridge commands until the OpenClaw plugin can write

--- a/src/core/ai/codex-extraction-client.ts
+++ b/src/core/ai/codex-extraction-client.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_CODEX_EXTRACTION_MODEL = 'openai-codex/gpt-5.4-mini';
-const DEFAULT_OPENCLAW_COMPLETION_PATH = '/plugins/gbrain/complete';
+const LEGACY_OPENCLAW_COMPLETION_PATH = '/plugins/gbrain/complete';
 const DEFAULT_OPENCLAW_EXTRACT_PATH = '/plugins/gbrain/extract';
 
 export interface CodexExtractionRequest {
@@ -47,7 +47,7 @@ export function createConfiguredCodexExtractionClient(env: CodexExtractionEnv = 
     return new OpenClawGatewayCodexExtractionClient({
       gatewayUrl,
       gatewayToken,
-      completionPath: env.GBRAIN_OPENCLAW_COMPLETION_PATH?.trim() || DEFAULT_OPENCLAW_COMPLETION_PATH,
+      completionPath: env.GBRAIN_OPENCLAW_COMPLETION_PATH?.trim() || undefined,
       extractPath: env.GBRAIN_OPENCLAW_EXTRACT_PATH?.trim() || DEFAULT_OPENCLAW_EXTRACT_PATH,
     });
   }
@@ -62,12 +62,12 @@ export class OpenClawGatewayCodexExtractionClient implements CodexExtractionClie
   constructor(private readonly options: { gatewayUrl: string; gatewayToken?: string; completionPath?: string; extractPath?: string }) {}
 
   async completeText(request: CodexExtractionRequest): Promise<string> {
-    const reply = await this.callBridge(request, false);
+    const reply = await this.callLegacyCompletionBridge(request, false);
     return coerceTextReply(JSON.stringify(reply));
   }
 
   async completeJson<T = unknown>(request: CodexExtractionRequest): Promise<T> {
-    const reply = await this.callBridge(request, true);
+    const reply = await this.callLegacyCompletionBridge(request, true);
     if (isRecord(reply) && reply.json !== undefined) return reply.json as T;
     return parseCodexJsonReply(JSON.stringify(reply)) as T;
   }
@@ -99,8 +99,17 @@ export class OpenClawGatewayCodexExtractionClient implements CodexExtractionClie
     return parsed as T;
   }
 
-  private async callBridge(request: CodexExtractionRequest, json: boolean): Promise<unknown> {
-    const url = new URL(this.options.completionPath ?? DEFAULT_OPENCLAW_COMPLETION_PATH, normalizeGatewayUrl(this.options.gatewayUrl));
+  private async callLegacyCompletionBridge(request: CodexExtractionRequest, json: boolean): Promise<unknown> {
+    const completionPath = this.options.completionPath?.trim();
+    if (!completionPath) {
+      throw new Error(
+        'OpenClaw gateway generic completion is not enabled on the default /plugins/gbrain/extract route. ' +
+        'Use extractMedia() for OAuth-backed media extraction, or use GBRAIN_OPENCLAW_COMPLETION_COMMAND for text-only fallback. ' +
+        `Set GBRAIN_OPENCLAW_COMPLETION_PATH=${LEGACY_OPENCLAW_COMPLETION_PATH} only when targeting a legacy completion bridge.`,
+      );
+    }
+
+    const url = new URL(completionPath, normalizeGatewayUrl(this.options.gatewayUrl));
     const headers: Record<string, string> = { 'content-type': 'application/json' };
     if (this.options.gatewayToken) headers.authorization = `Bearer ${this.options.gatewayToken}`;
     const res = await fetch(url, {
@@ -115,9 +124,9 @@ export class OpenClawGatewayCodexExtractionClient implements CodexExtractionClie
       signal: request.signal,
     });
     const text = await res.text();
-    if (!res.ok) throw new Error(`OpenClaw completion bridge failed (${res.status}): ${text || res.statusText}`);
-    const parsed = parseJson(text, 'OpenClaw completion bridge returned non-JSON output');
-    if (isRecord(parsed) && parsed.ok === false) throw new Error(`OpenClaw completion bridge failed: ${String(parsed.error ?? 'unknown error')}`);
+    if (!res.ok) throw new Error(`OpenClaw legacy completion bridge failed (${res.status}): ${text || res.statusText}`);
+    const parsed = parseJson(text, 'OpenClaw legacy completion bridge returned non-JSON output');
+    if (isRecord(parsed) && parsed.ok === false) throw new Error(`OpenClaw legacy completion bridge failed: ${String(parsed.error ?? 'unknown error')}`);
     return parsed;
   }
 }

--- a/test/codex-extraction-client.test.ts
+++ b/test/codex-extraction-client.test.ts
@@ -86,6 +86,42 @@ describe('CodexExtractionClient', () => {
     }
   });
 
+  test('refuses generic gateway completion unless a legacy completion path is explicitly configured', async () => {
+    const client = new OpenClawGatewayCodexExtractionClient({ gatewayUrl: 'http://127.0.0.1:18789' });
+
+    await expect(client.completeJson({ prompt: 'extract JSON' })).rejects.toThrow(
+      'OpenClaw gateway generic completion is not enabled on the default /plugins/gbrain/extract route.',
+    );
+  });
+
+  test('supports the legacy gateway completion bridge only when explicitly configured', async () => {
+    const requests: Array<{ url: string; init: RequestInit }> = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      requests.push({ url: String(url), init: init ?? {} });
+      return new Response(JSON.stringify({ ok: true, json: { summary: 'ok' } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+    try {
+      const client = new OpenClawGatewayCodexExtractionClient({
+        gatewayUrl: 'http://127.0.0.1:18789',
+        completionPath: '/plugins/gbrain/complete',
+      });
+      const json = await client.completeJson<{ summary: string }>({ prompt: 'extract JSON' });
+
+      expect(json.summary).toBe('ok');
+      expect(requests).toHaveLength(1);
+      expect(requests[0].url).toBe('http://127.0.0.1:18789/plugins/gbrain/complete');
+      const body = JSON.parse(String(requests[0].init.body));
+      expect(body.protocol).toBe('gbrain.codex-extraction.v1');
+      expect(body.prompt).toBe('extract JSON');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test('sends image bytes to the OpenClaw extraction route without model API keys', async () => {
     const requests: Array<{ url: string; init: RequestInit }> = [];
     const originalFetch = globalThis.fetch;
@@ -116,5 +152,9 @@ describe('CodexExtractionClient', () => {
     expect(createConfiguredCodexExtractionClient({})).toBeUndefined();
     expect(createConfiguredCodexExtractionClient({ GBRAIN_OPENCLAW_COMPLETION_COMMAND: 'cat' })).toBeTruthy();
     expect(createConfiguredCodexExtractionClient({ GBRAIN_OPENCLAW_GATEWAY_URL: 'http://127.0.0.1:18789' })).toBeTruthy();
+    expect(createConfiguredCodexExtractionClient({
+      GBRAIN_OPENCLAW_GATEWAY_URL: 'http://127.0.0.1:18789',
+      GBRAIN_OPENCLAW_COMPLETION_PATH: '/plugins/gbrain/complete',
+    })).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Why

The live OpenClaw GBrain plugin already uses `/plugins/gbrain/extract`, but the repo-side Codex extraction client still silently defaulted generic gateway completion calls to `/plugins/gbrain/complete`.

That was a real drift between the product path we actually run and the fallback path the repo still implied. The important thing here is not removing flexibility; it is making the default honest.

With this change, the default story becomes:

- GBrain uses `/plugins/gbrain/extract` for OAuth-backed host execution
- the OpenClaw plugin owns queueing, limits, and normalization
- `GBRAIN_OPENCLAW_COMPLETION_COMMAND` remains the text-only fallback for hosts that cannot accept file media
- legacy `/plugins/gbrain/complete` survives only as an explicit opt-in override

Closes #71.

## What changed

- removed the silent default of `/plugins/gbrain/complete` from the gateway client
- kept `/plugins/gbrain/extract` as the repo and live-install default route
- made gateway `completeText()` / `completeJson()` fail clearly unless `GBRAIN_OPENCLAW_COMPLETION_PATH` is explicitly set for a legacy host
- updated the media guide to document the new rule
- added tests for:
  - refusing generic gateway completion on the default extract route
  - allowing the legacy completion bridge only when explicitly configured
  - preserving the real extraction route and text-only command fallback behavior

## Why this is the right boundary

This keeps the fork aligned with the production OAuth path we actually want:

- OpenClaw core/plugin owns runtime auth and model execution
- the GBrain plugin owns `/plugins/gbrain/extract` and `gbrain.media-extraction.v1`
- GBrain core owns importing normalized evidence into searchable pages/chunks/files

It also lines up with the broader OpenClaw follow-up we just filed upstream in [openclaw/openclaw#80188](https://github.com/openclaw/openclaw/issues/80188): bounded host-owned plugin inference should live in OpenClaw, while product plugins keep their own routes and schemas.

## Validation

```bash
bun run verify
bun test test/codex-extraction-client.test.ts test/media-ingest-openclaw.serial.test.ts test/media-ingest.serial.test.ts
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified legacy OpenClaw adapter completion path behavior and configuration options.

* **Bug Fixes**
  * Legacy completion path now requires explicit configuration; default behavior uses standard extraction path. Enhanced error messages guide users to appropriate alternatives.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/eva-brain/pull/72)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->