### PR TITLE
Fix local canary install smoke regressions

### DIFF
--- a/plugins/openclaw-gbrain/README.md
+++ b/plugins/openclaw-gbrain/README.md
@@ -97,7 +97,7 @@ default; the hard plugin cap is 20 MiB.
 ```bash
 gbrain --version
 gbrain health
-openclaw infer model run --gateway --model openai-codex/gpt-5.4-mini --prompt 'Return only JSON: {"ok":true}' --json
+openclaw infer model run --local --model openai-codex/gpt-5.4-mini --prompt 'Return only JSON: {"ok":true}' --json
 openclaw gbrain status
 ```
 

--- a/plugins/openclaw-gbrain/index.js
+++ b/plugins/openclaw-gbrain/index.js
@@ -332,7 +332,7 @@ async function handleExtractionRoute(config, req, res) {
       "infer",
       "model",
       "run",
-      "--gateway",
+      "--local",
       "--model",
       resolveExtractionModel(request.model, config.extractionModel),
       "--prompt",

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1008,16 +1008,20 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
 
   // 4. pgvector extension
   progress.heartbeat('pgvector');
-  try {
-    const sql = db.getConnection();
-    const ext = await sql`SELECT extname FROM pg_extension WHERE extname = 'vector'`;
-    if (ext.length > 0) {
-      checks.push({ name: 'pgvector', status: 'ok', message: 'Extension installed' });
-    } else {
-      checks.push({ name: 'pgvector', status: 'fail', message: 'Extension not found. Run: CREATE EXTENSION vector;' });
+  if (engine.kind === 'pglite') {
+    checks.push({ name: 'pgvector', status: 'ok', message: 'Skipped (PGLite bundles vector support)' });
+  } else {
+    try {
+      const sql = db.getConnection();
+      const ext = await sql`SELECT extname FROM pg_extension WHERE extname = 'vector'`;
+      if (ext.length > 0) {
+        checks.push({ name: 'pgvector', status: 'ok', message: 'Extension installed' });
+      } else {
+        checks.push({ name: 'pgvector', status: 'fail', message: 'Extension not found. Run: CREATE EXTENSION vector;' });
+      }
+    } catch {
+      checks.push({ name: 'pgvector', status: 'warn', message: 'Could not check pgvector extension' });
     }
-  } catch {
-    checks.push({ name: 'pgvector', status: 'warn', message: 'Could not check pgvector extension' });
   }
 
   // 4b. PgBouncer / prepared-statement compatibility.
@@ -1472,36 +1476,40 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
   // surface matches `repair-jsonb` (the previous 4-target scan missed a
   // repair target, per #254/Codex review).
   progress.heartbeat('jsonb_integrity');
-  try {
-    const sql = db.getConnection();
-    const targets: Array<{ table: string; col: string; expected: 'object' | 'array' }> = [
-      { table: 'pages',         col: 'frontmatter',    expected: 'object' },
-      { table: 'raw_data',      col: 'data',           expected: 'object' },
-      { table: 'ingest_log',    col: 'pages_updated',  expected: 'array'  },
-      { table: 'files',         col: 'metadata',       expected: 'object' },
-      { table: 'page_versions', col: 'frontmatter',    expected: 'object' },
-    ];
-    let totalBad = 0;
-    const breakdown: string[] = [];
-    for (const { table, col } of targets) {
-      progress.heartbeat(`jsonb_integrity.${table}.${col}`);
-      const rows = await sql.unsafe(
-        `SELECT count(*)::int AS n FROM ${table} WHERE jsonb_typeof(${col}) = 'string'`,
-      );
-      const n = Number((rows as any)[0]?.n ?? 0);
-      if (n > 0) { totalBad += n; breakdown.push(`${table}.${col}=${n}`); }
+  if (engine.kind === 'pglite') {
+    checks.push({ name: 'jsonb_integrity', status: 'ok', message: 'Skipped (PGLite JSONB probe not applicable)' });
+  } else {
+    try {
+      const sql = db.getConnection();
+      const targets: Array<{ table: string; col: string; expected: 'object' | 'array' }> = [
+        { table: 'pages',         col: 'frontmatter',    expected: 'object' },
+        { table: 'raw_data',      col: 'data',           expected: 'object' },
+        { table: 'ingest_log',    col: 'pages_updated',  expected: 'array'  },
+        { table: 'files',         col: 'metadata',       expected: 'object' },
+        { table: 'page_versions', col: 'frontmatter',    expected: 'object' },
+      ];
+      let totalBad = 0;
+      const breakdown: string[] = [];
+      for (const { table, col } of targets) {
+        progress.heartbeat(`jsonb_integrity.${table}.${col}`);
+        const rows = await sql.unsafe(
+          `SELECT count(*)::int AS n FROM ${table} WHERE jsonb_typeof(${col}) = 'string'`,
+        );
+        const n = Number((rows as any)[0]?.n ?? 0);
+        if (n > 0) { totalBad += n; breakdown.push(`${table}.${col}=${n}`); }
+      }
+      if (totalBad === 0) {
+        checks.push({ name: 'jsonb_integrity', status: 'ok', message: 'All JSONB columns store objects/arrays' });
+      } else {
+        checks.push({
+          name: 'jsonb_integrity',
+          status: 'warn',
+          message: `${totalBad} row(s) double-encoded (${breakdown.join(', ')}). Fix: gbrain repair-jsonb`,
+        });
+      }
+    } catch {
+      checks.push({ name: 'jsonb_integrity', status: 'warn', message: 'Could not check JSONB integrity' });
     }
-    if (totalBad === 0) {
-      checks.push({ name: 'jsonb_integrity', status: 'ok', message: 'All JSONB columns store objects/arrays' });
-    } else {
-      checks.push({
-        name: 'jsonb_integrity',
-        status: 'warn',
-        message: `${totalBad} row(s) double-encoded (${breakdown.join(', ')}). Fix: gbrain repair-jsonb`,
-      });
-    }
-  } catch {
-    checks.push({ name: 'jsonb_integrity', status: 'warn', message: 'Could not check JSONB integrity' });
   }
 
   // 10b. Takes weight grid integrity (v0.32 — EXP-2).

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -541,6 +541,8 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       detachedWorkingTreeManifest.renamed.length > 0);
 
   if (lastCommit === headCommit && !versionMismatch && !versionNeverSet && !hasDetachedWorkingTreeChanges) {
+    await writeSyncAnchor(engine, opts.sourceId, 'last_commit', headCommit);
+    await engine.setConfig('sync.last_run', new Date().toISOString());
     return {
       status: 'up_to_date',
       fromCommit: lastCommit,

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -102,6 +102,26 @@ describe('doctor command', () => {
     expect(source).toMatch(/table:\s*'files'.*col:\s*'metadata'/);
   });
 
+  test('pgvector check skips on PGLite because vector support is bundled', async () => {
+    const source = await Bun.file(new URL('../src/commands/doctor.ts', import.meta.url)).text();
+    const block = source.slice(
+      source.indexOf('// 4. pgvector extension'),
+      source.indexOf('// 4b. PgBouncer'),
+    );
+    expect(block).toContain("engine.kind === 'pglite'");
+    expect(block).toContain('PGLite bundles vector support');
+  });
+
+  test('jsonb_integrity skips on PGLite because raw Postgres JSONB probe is not applicable', async () => {
+    const source = await Bun.file(new URL('../src/commands/doctor.ts', import.meta.url)).text();
+    const block = source.slice(
+      source.indexOf('// 10. JSONB integrity'),
+      source.indexOf('// 10b. Takes weight grid integrity'),
+    );
+    expect(block).toContain("engine.kind === 'pglite'");
+    expect(block).toContain('PGLite JSONB probe not applicable');
+  });
+
   // v0.31.2 — facts_extraction_health check added in PR1 commit 12.
   // Reads ingest_log rows with source_type='facts:absorb' (written by
   // writeFactsAbsorbLog from src/core/facts/absorb-log.ts), groups by

--- a/test/openclaw-gbrain-plugin-contract.test.ts
+++ b/test/openclaw-gbrain-plugin-contract.test.ts
@@ -14,6 +14,8 @@ describe('OpenClaw GBrain plugin boundary', () => {
     expect(pluginSource).toContain('GBRAIN_ROUTE_PATH = "/plugins/gbrain/extract"');
     expect(pluginSource).toContain('api.registerHttpRoute');
     expect(pluginSource).toContain('auth: "gateway"');
+    expect(pluginSource).toContain('"--local"');
+    expect(pluginSource).not.toContain('"--gateway"');
     expect(pluginSource).toContain('protocol: "gbrain.media-extraction.v1"');
     expect(pluginSource).toContain('provider: "openai-codex"');
   });

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -309,6 +309,42 @@ describe('performSync dry-run never writes', () => {
     expect(rows[0].last_sync_at).toBeTruthy();
   });
 
+  test('source-scoped up-to-date sync refreshes last_sync_at for freshness doctor', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    const head = execSync('git rev-parse HEAD', { cwd: repoPath, encoding: 'utf8' }).trim();
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path, last_commit, config)
+       VALUES ('supportkb', 'Support KB', $1, NULL, '{}'::jsonb)`,
+      [repoPath],
+    );
+
+    const first = await performSync(engine, {
+      sourceId: 'supportkb',
+      noPull: true,
+      noEmbed: true,
+    });
+    expect(first.status).toBe('first_sync');
+
+    const staleIso = '2026-01-01T00:00:00.000Z';
+    await engine.executeRaw(
+      `UPDATE sources SET last_sync_at = $1 WHERE id = 'supportkb'`,
+      [staleIso],
+    );
+
+    const second = await performSync(engine, {
+      sourceId: 'supportkb',
+      noPull: true,
+      noEmbed: true,
+    });
+    expect(second.status).toBe('up_to_date');
+
+    const rows = await engine.executeRaw<{ last_commit: string | null; last_sync_at: unknown }>(
+      `SELECT last_commit, last_sync_at FROM sources WHERE id = 'supportkb'`,
+    );
+    expect(rows[0].last_commit).toBe(head);
+    expect(new Date(rows[0].last_sync_at as string).getTime()).toBeGreaterThan(new Date(staleIso).getTime());
+  });
+
   test('incremental dry-run does NOT write to DB or advance the bookmark', async () => {
     const { performSync } = await import('../src/commands/sync.ts');
     // First do a real sync to seed the bookmark.


### PR DESCRIPTION
## Why

The local Ring 0 canary after the v0.33 update exposed three install-smoke regressions that would make fleet rollout noisy or misleading:

1. `/plugins/gbrain/extract` invoked `openclaw infer model run --gateway`, which routed into the gateway/default quota path instead of the logged-in local Codex OAuth runtime.
2. `gbrain sync --source <id>` returned `Already up to date` without refreshing `last_sync_at`, so doctor kept warning about stale source freshness after a successful no-op sync.
3. PGLite installs lost doctor points on PostgreSQL-only `pgvector`/JSONB probes even when schema, embeddings, and vector behavior were healthy.

This PR keeps the thin-fork direction: no new core product surface, just canary fixes that make local and fleet installs report the truth.

Closes #81.

## What changed

- Switch the OpenClaw GBrain plugin extraction route to `openclaw infer model run --local` so extraction uses the local Codex OAuth runtime and does not require model API keys.
- Refresh source sync anchors/timestamps in the up-to-date sync path so `sync_freshness` reflects successful no-op syncs.
- Treat PGLite `pgvector` and raw JSONB integrity checks as not-applicable/healthy instead of warning on Postgres-only probes.
- Add focused regression coverage for the plugin runtime flag, no-op source sync freshness, and PGLite doctor skips.

## Local canary evidence

- `/Users/lume/.bun/bin/gbrain --version`: `gbrain 0.33.0`.
- `/Users/lume/.bun/bin/gbrain doctor --json`: `status=healthy`, `health_score=100`, schema version 54, Voyage `voyage:voyage-4-large` aligned at 2048 dims, 100% embedding coverage.
- `/Users/lume/.bun/bin/gbrain sync --source openclaw-support-kb --no-pull --skip-failed`: `Already up to date`; immediate doctor rerun stayed `100/100` with sources fresh.
- Direct POST to local OpenClaw `/plugins/gbrain/extract`: HTTP 200, `gbrain.media-extraction.v1`, model `openai-codex/gpt-5.4-mini`.
- `GBRAIN_SOURCE=default /Users/lume/.bun/bin/gbrain search "Fleet-safe canary phrase" --limit 3`: returns the imported OpenClaw media canary.
- `openclaw plugins inspect gbrain --runtime --json`: plugin loaded with `gbrain_status`, `gbrain_search`, `gbrain_query`, and one HTTP route.

## Validation

Local focused checks from `/Volumes/LEXAR/repos/eva-brain`:

```bash
git diff --check
bun test test/doctor.test.ts test/sync.test.ts test/openclaw-gbrain-plugin-contract.test.ts
```

Result: `95 pass`, `0 fail`, `277 expect() calls`.

Full `verify`/full-suite validation is intentionally left to GitHub Actions to avoid another heavy local run on the desktop canary machine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sync state not being properly persisted when the repository is already synchronized and up-to-date with the latest changes.
  * Improved database health checks with enhanced support for PGLite databases, including validation of database extensions and data integrity.
  * Extraction service configuration updated to operate in local mode instead of gateway mode.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/eva-brain/pull/82)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->