### PR TITLE
Add public updater and Codex plugin package

### DIFF
--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -17,6 +17,23 @@ If you fetched this file by URL without cloning yet, the companion files live at
 
 ## Step 1: Install GBrain
 
+Recommended public updater path:
+
+```bash
+git clone https://github.com/electricsheephq/eva-brain.git ~/eva-brain
+cd ~/eva-brain
+scripts/update-local-install.sh
+```
+
+That script is idempotent: it updates the checkout, runs `bun install`, links
+the `gbrain` CLI, applies safe PGLite migrations, and refreshes optional host
+plugins when those hosts are present.
+
+To require host plugin setup instead of auto-detecting it, pass
+`--with-openclaw` and/or `--with-codex-plugin`.
+
+Manual path:
+
 ```bash
 git clone https://github.com/electricsheephq/eva-brain.git ~/eva-brain && cd ~/eva-brain
 curl -fsSL https://bun.sh/install | bash
@@ -103,7 +120,25 @@ continues to shrink toward upstream-native writes.
 
 If OpenClaw is not installed, skip this step and keep the CLI/MCP path.
 
-## Step 3.6: Install The OpenClaw Support KB
+## Step 3.6: Install The Codex Desktop Plugin
+
+If Codex Desktop is installed on this machine, install the local Codex plugin
+from the same Eva Brain checkout:
+
+```bash
+cd ~/eva-brain
+node scripts/install-codex-plugin.mjs
+```
+
+Then restart Codex Desktop. The installer creates `~/plugins/gbrain-codex`,
+links the repo-owned plugin package plus the current repo `skills/` tree, and
+updates `~/.agents/plugins/marketplace.json`.
+
+The plugin is a thin MCP adapter over the local `gbrain` CLI. It does not embed
+a second brain runtime. If Codex cannot see `gbrain` on the GUI PATH, set
+`GBRAIN_CODEX_BIN` to the desired executable path before launching Codex.
+
+## Step 3.7: Install The OpenClaw Support KB
 
 For OpenClaw customer/support work, install the KB source and support skills
 after GBrain is healthy:
@@ -236,8 +271,8 @@ actually works) is the most important.
 ## Upgrade
 
 ```bash
-cd ~/eva-brain && git pull origin master && bun install
-gbrain init                           # apply schema migrations (idempotent)
+cd ~/eva-brain
+scripts/update-local-install.sh
 gbrain post-upgrade                   # show migration notes for the version range
 ```
 

--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -145,8 +145,11 @@ after GBrain is healthy:
 
 ```bash
 export OPENCLAW_SUPPORT_KB_REPO="https://github.com/electricsheephq/openclaw-support-kb.git"
-export GBRAIN_PARENT="${GBRAIN_HOME:-$HOME}"
-export OPENCLAW_SUPPORT_KB_DIR="$GBRAIN_PARENT/.gbrain/sources/openclaw-support-kb"
+export GBRAIN_ROOT="${GBRAIN_HOME:-$HOME}"
+if [ "${GBRAIN_ROOT%/.gbrain}" != "$GBRAIN_ROOT" ]; then
+  export GBRAIN_ROOT="$(dirname "$GBRAIN_ROOT")"
+fi
+export OPENCLAW_SUPPORT_KB_DIR="$GBRAIN_ROOT/.gbrain/sources/openclaw-support-kb"
 
 if [ -d "$OPENCLAW_SUPPORT_KB_DIR/.git" ]; then
   git -C "$OPENCLAW_SUPPORT_KB_DIR" pull --ff-only

--- a/README.md
+++ b/README.md
@@ -36,7 +36,19 @@ Retrieve and follow the instructions at:
 https://raw.githubusercontent.com/electricsheephq/eva-brain/master/INSTALL_FOR_AGENTS.md
 ```
 
-That's it. The agent clones Eva Brain, installs GBrain, sets up a Voyage 4 Large 2048d brain when `VOYAGE_API_KEY` is available, installs the OpenClaw plugin, and verifies the local doctor score. ~30 minutes.
+That's it. The agent clones Eva Brain, runs the public updater script, installs
+GBrain, sets up a Voyage 4 Large 2048d brain when `VOYAGE_API_KEY` is available,
+installs host plugins such as OpenClaw and Codex Desktop when those hosts are
+present, and verifies the local doctor score. ~30 minutes.
+
+For manual installs or upgrades from an existing checkout:
+
+```bash
+scripts/update-local-install.sh
+```
+
+Use `--with-openclaw` or `--with-codex-plugin` when you want the script to fail
+instead of auto-skipping a missing host.
 
 For provider choice, embedding dimensions, Voyage 4 Large 2048d setup, and the OpenClaw Codex OAuth extraction boundary, read [`docs/guides/provider-install-matrix.md`](docs/guides/provider-install-matrix.md).
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ present, and verifies the local doctor score. ~30 minutes.
 For manual installs or upgrades from an existing checkout:
 
 ```bash
+cd ~/eva-brain
 scripts/update-local-install.sh
 ```
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1571,6 +1571,23 @@ If you fetched this file by URL without cloning yet, the companion files live at
 
 ## Step 1: Install GBrain
 
+Recommended public updater path:
+
+```bash
+git clone https://github.com/electricsheephq/eva-brain.git ~/eva-brain
+cd ~/eva-brain
+scripts/update-local-install.sh
+```
+
+That script is idempotent: it updates the checkout, runs `bun install`, links
+the `gbrain` CLI, applies safe PGLite migrations, and refreshes optional host
+plugins when those hosts are present.
+
+To require host plugin setup instead of auto-detecting it, pass
+`--with-openclaw` and/or `--with-codex-plugin`.
+
+Manual path:
+
 ```bash
 git clone https://github.com/electricsheephq/eva-brain.git ~/eva-brain && cd ~/eva-brain
 curl -fsSL https://bun.sh/install | bash
@@ -1657,7 +1674,25 @@ continues to shrink toward upstream-native writes.
 
 If OpenClaw is not installed, skip this step and keep the CLI/MCP path.
 
-## Step 3.6: Install The OpenClaw Support KB
+## Step 3.6: Install The Codex Desktop Plugin
+
+If Codex Desktop is installed on this machine, install the local Codex plugin
+from the same Eva Brain checkout:
+
+```bash
+cd ~/eva-brain
+node scripts/install-codex-plugin.mjs
+```
+
+Then restart Codex Desktop. The installer creates `~/plugins/gbrain-codex`,
+links the repo-owned plugin package plus the current repo `skills/` tree, and
+updates `~/.agents/plugins/marketplace.json`.
+
+The plugin is a thin MCP adapter over the local `gbrain` CLI. It does not embed
+a second brain runtime. If Codex cannot see `gbrain` on the GUI PATH, set
+`GBRAIN_CODEX_BIN` to the desired executable path before launching Codex.
+
+## Step 3.7: Install The OpenClaw Support KB
 
 For OpenClaw customer/support work, install the KB source and support skills
 after GBrain is healthy:
@@ -1790,8 +1825,8 @@ actually works) is the most important.
 ## Upgrade
 
 ```bash
-cd ~/eva-brain && git pull origin master && bun install
-gbrain init                           # apply schema migrations (idempotent)
+cd ~/eva-brain
+scripts/update-local-install.sh
 gbrain post-upgrade                   # show migration notes for the version range
 ```
 
@@ -1985,7 +2020,19 @@ Retrieve and follow the instructions at:
 https://raw.githubusercontent.com/electricsheephq/eva-brain/master/INSTALL_FOR_AGENTS.md
 ```
 
-That's it. The agent clones Eva Brain, installs GBrain, sets up a Voyage 4 Large 2048d brain when `VOYAGE_API_KEY` is available, installs the OpenClaw plugin, and verifies the local doctor score. ~30 minutes.
+That's it. The agent clones Eva Brain, runs the public updater script, installs
+GBrain, sets up a Voyage 4 Large 2048d brain when `VOYAGE_API_KEY` is available,
+installs host plugins such as OpenClaw and Codex Desktop when those hosts are
+present, and verifies the local doctor score. ~30 minutes.
+
+For manual installs or upgrades from an existing checkout:
+
+```bash
+scripts/update-local-install.sh
+```
+
+Use `--with-openclaw` or `--with-codex-plugin` when you want the script to fail
+instead of auto-skipping a missing host.
 
 For provider choice, embedding dimensions, Voyage 4 Large 2048d setup, and the OpenClaw Codex OAuth extraction boundary, read [`docs/guides/provider-install-matrix.md`](docs/guides/provider-install-matrix.md).
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1699,8 +1699,11 @@ after GBrain is healthy:
 
 ```bash
 export OPENCLAW_SUPPORT_KB_REPO="https://github.com/electricsheephq/openclaw-support-kb.git"
-export GBRAIN_PARENT="${GBRAIN_HOME:-$HOME}"
-export OPENCLAW_SUPPORT_KB_DIR="$GBRAIN_PARENT/.gbrain/sources/openclaw-support-kb"
+export GBRAIN_ROOT="${GBRAIN_HOME:-$HOME}"
+if [ "${GBRAIN_ROOT%/.gbrain}" != "$GBRAIN_ROOT" ]; then
+  export GBRAIN_ROOT="$(dirname "$GBRAIN_ROOT")"
+fi
+export OPENCLAW_SUPPORT_KB_DIR="$GBRAIN_ROOT/.gbrain/sources/openclaw-support-kb"
 
 if [ -d "$OPENCLAW_SUPPORT_KB_DIR/.git" ]; then
   git -C "$OPENCLAW_SUPPORT_KB_DIR" pull --ff-only
@@ -2028,6 +2031,7 @@ present, and verifies the local doctor score. ~30 minutes.
 For manual installs or upgrades from an existing checkout:
 
 ```bash
+cd ~/eva-brain
 scripts/update-local-install.sh
 ```
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "ci:local": "bash scripts/ci-local.sh",
     "ci:local:diff": "bash scripts/ci-local.sh --diff",
     "ci:select-e2e": "bun run scripts/select-e2e.ts",
+    "install:codex-plugin": "node scripts/install-codex-plugin.mjs",
+    "rehearse:codex-plugin": "node plugins/gbrain-codex/scripts/rehearsal.mjs",
     "typecheck": "tsc --noEmit",
     "check:jsonb": "scripts/check-jsonb-pattern.sh",
     "check:source-id-projection": "scripts/check-source-id-projection.sh",

--- a/plugins/gbrain-codex/.codex-plugin/plugin.json
+++ b/plugins/gbrain-codex/.codex-plugin/plugin.json
@@ -1,0 +1,47 @@
+{
+  "name": "gbrain-codex",
+  "version": "0.33.0",
+  "description": "Full-surface Codex Desktop adapter for a local Eva Brain/GBrain install.",
+  "author": {
+    "name": "Electric Sheep",
+    "url": "https://github.com/electricsheephq"
+  },
+  "homepage": "https://github.com/electricsheephq/eva-brain",
+  "repository": "https://github.com/electricsheephq/eva-brain",
+  "license": "MIT",
+  "keywords": [
+    "gbrain",
+    "eva-brain",
+    "codex",
+    "mcp",
+    "knowledge-base",
+    "search",
+    "agent"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Eva Brain",
+    "shortDescription": "Use a local Eva Brain/GBrain from Codex Desktop",
+    "longDescription": "Eva Brain for Codex Desktop is a thin local adapter over an already-installed GBrain CLI. It launches `gbrain serve`, exposes the same MCP tools GBrain already serves to other hosts, and uses the repo's current skillpack so Codex can search, write, sync, and operate the brain with upstream behavior.",
+    "developerName": "Electric Sheep",
+    "category": "Engineering",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/electricsheephq/eva-brain",
+    "privacyPolicyURL": "https://github.com/electricsheephq/eva-brain/blob/master/SECURITY.md",
+    "termsOfServiceURL": "https://github.com/electricsheephq/eva-brain/blob/master/LICENSE",
+    "defaultPrompt": [
+      "Search my Eva Brain for prior context on this topic",
+      "Write this note into Eva Brain and link it correctly",
+      "Sync the brain and tell me what changed"
+    ],
+    "brandColor": "#2563EB",
+    "composerIcon": "./assets/gbrain-codex.svg",
+    "logo": "./assets/gbrain-codex.svg",
+    "screenshots": []
+  }
+}

--- a/plugins/gbrain-codex/.mcp.json
+++ b/plugins/gbrain-codex/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "gbrain-codex": {
+      "type": "stdio",
+      "command": "node",
+      "args": [
+        "./scripts/launch-gbrain-serve.mjs"
+      ],
+      "cwd": "."
+    }
+  }
+}

--- a/plugins/gbrain-codex/README.md
+++ b/plugins/gbrain-codex/README.md
@@ -1,0 +1,73 @@
+# Eva Brain for Codex Desktop
+
+This package makes Eva Brain/GBrain available to Codex Desktop as a local
+plugin.
+
+It is intentionally thin:
+
+- Codex launches `node ./scripts/launch-gbrain-serve.mjs`
+- that launcher resolves a local `gbrain` executable
+- then it runs the canonical server via `gbrain serve`
+
+There is no second MCP server here, and no forked search or write logic inside
+the plugin package. Codex sees the same GBrain MCP surface that other stdio
+hosts see.
+
+## What You Get
+
+- the current GBrain MCP tool surface
+- the current repo skill tree, linked into the installed plugin by
+  `scripts/install-codex-plugin.mjs`
+- the same remote/untrusted MCP behavior GBrain already applies to stdio calls
+
+## Resolution Order
+
+The launcher resolves `gbrain` in this order:
+
+1. `GBRAIN_CODEX_BIN`
+2. repo-local `bin/gbrain`
+3. `gbrain` on `PATH` with `$HOME/.bun/bin` prepended
+
+If none resolve, the launcher fails with an install hint. This plugin is an
+adapter over a local GBrain install, not a standalone runtime bundle.
+
+## Install In Codex Desktop
+
+From the Eva Brain repo root:
+
+```bash
+bun install
+bun link
+node scripts/install-codex-plugin.mjs
+```
+
+Then restart Codex Desktop.
+
+The installer creates `~/plugins/gbrain-codex`, links this package plus the
+repo's current `skills/` tree, and updates
+`~/.agents/plugins/marketplace.json`.
+
+## Local Repo Smoke
+
+From the Eva Brain repo root:
+
+```bash
+bun install
+test -x "$HOME/.bun/bin/gbrain" || bun link
+node plugins/gbrain-codex/scripts/rehearsal.mjs
+```
+
+The rehearsal script creates a temp `GBRAIN_HOME`, initializes PGLite, connects
+to the plugin over stdio MCP, checks `tools/list`, and exercises `put_page`,
+`get_page`, `search`, `query`, `sync_brain`, and the `whoami` fail-closed path.
+
+## Safety Boundary
+
+This plugin does not add or loosen GBrain permissions.
+
+- Codex calls arrive through MCP stdio
+- GBrain treats those calls as `remote: true`
+- operation-level guards stay inside GBrain core
+
+That means Codex gets the full tool surface, but the same stdio-MCP trust
+boundary and restrictions still apply.

--- a/plugins/gbrain-codex/assets/gbrain-codex.svg
+++ b/plugins/gbrain-codex/assets/gbrain-codex.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="Eva Brain">
+  <rect width="128" height="128" rx="28" fill="#0f172a"/>
+  <path d="M36 71c-10-4-16-12-16-23 0-15 12-27 28-27 6 0 12 2 17 6 5-4 11-6 17-6 16 0 28 12 28 27 0 11-6 19-16 23" fill="none" stroke="#60a5fa" stroke-width="8" stroke-linecap="round"/>
+  <path d="M35 75c4 18 16 29 29 29s25-11 29-29" fill="none" stroke="#34d399" stroke-width="8" stroke-linecap="round"/>
+  <path d="M45 48h38M45 64h38M53 80h22" fill="none" stroke="#e2e8f0" stroke-width="7" stroke-linecap="round"/>
+</svg>

--- a/plugins/gbrain-codex/package.json
+++ b/plugins/gbrain-codex/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@eva-brain/gbrain-codex",
+  "version": "0.33.0",
+  "description": "Codex Desktop local plugin adapter for Eva Brain/GBrain.",
+  "type": "module",
+  "private": true,
+  "files": [
+    ".codex-plugin/plugin.json",
+    ".mcp.json",
+    "README.md",
+    "assets",
+    "scripts"
+  ],
+  "scripts": {
+    "rehearsal": "node ./scripts/rehearsal.mjs"
+  },
+  "license": "MIT"
+}

--- a/plugins/gbrain-codex/scripts/launch-gbrain-serve.mjs
+++ b/plugins/gbrain-codex/scripts/launch-gbrain-serve.mjs
@@ -1,0 +1,148 @@
+import { spawn } from 'node:child_process';
+import { accessSync, constants, existsSync } from 'node:fs';
+import { userInfo } from 'node:os';
+import { delimiter, dirname, isAbsolute, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const PLUGIN_ROOT = resolve(dirname(SCRIPT_PATH), '..');
+
+function isExecutable(path) {
+  try {
+    accessSync(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolvePathCandidate(candidate) {
+  if (!candidate) return null;
+  return isAbsolute(candidate) ? candidate : resolve(candidate);
+}
+
+function resolveOnPath(binaryName, pathValue) {
+  for (const dir of String(pathValue || '').split(delimiter).filter(Boolean)) {
+    const candidate = join(dir, binaryName);
+    if (isExecutable(candidate)) return candidate;
+  }
+  return null;
+}
+
+export function prependBunBinToPath(pathValue = '', home = '') {
+  const existing = String(pathValue || '').split(delimiter).filter(Boolean);
+  const candidates = [];
+  if (home) candidates.push(join(home, '.bun', 'bin'));
+
+  try {
+    const realHome = userInfo().homedir;
+    if (realHome) candidates.push(join(realHome, '.bun', 'bin'));
+  } catch {
+    // Best effort only; PATH fallback still applies below.
+  }
+
+  const seen = new Set();
+  const bunBins = candidates.filter(entry => {
+    if (!entry || seen.has(entry)) return false;
+    seen.add(entry);
+    return true;
+  });
+
+  const deduped = existing.filter(entry => !seen.has(entry));
+  return [...bunBins, ...deduped].join(delimiter);
+}
+
+export function buildServeArgs(extraArgs = []) {
+  return ['serve', ...extraArgs];
+}
+
+function gbrainConfigPath(home) {
+  return home ? join(home, '.gbrain', 'config.json') : '';
+}
+
+export function resolveGbrainHome(env = process.env) {
+  const explicit = env.GBRAIN_HOME;
+  if (explicit) return explicit;
+
+  const envHome = env.HOME || '';
+  if (envHome && existsSync(gbrainConfigPath(envHome))) return envHome;
+
+  try {
+    const realHome = userInfo().homedir;
+    if (realHome && existsSync(gbrainConfigPath(realHome))) return realHome;
+  } catch {
+    // Best effort only; gbrain will surface its own config error if absent.
+  }
+
+  return undefined;
+}
+
+export function resolveGbrainExecutable({
+  pluginRoot = PLUGIN_ROOT,
+  env = process.env,
+} = {}) {
+  const pathValue = prependBunBinToPath(env.PATH || '', env.HOME || '');
+  const envOverride = resolvePathCandidate(env.GBRAIN_CODEX_BIN);
+  if (envOverride) {
+    if (!isExecutable(envOverride)) {
+      throw new Error(
+        `GBRAIN_CODEX_BIN points to a non-executable path: ${envOverride}\n` +
+        `The Codex GBrain plugin is an adapter over a local GBrain install. ` +
+        `Set GBRAIN_CODEX_BIN to a working gbrain binary, build ./bin/gbrain in this repo, or put gbrain on PATH.`,
+      );
+    }
+    return { command: envOverride, source: 'env', envPath: pathValue };
+  }
+
+  const repoCandidate = resolve(pluginRoot, '..', '..', 'bin', 'gbrain');
+  if (isExecutable(repoCandidate)) {
+    return { command: repoCandidate, source: 'repo', envPath: pathValue };
+  }
+
+  const pathCandidate = resolveOnPath('gbrain', pathValue);
+  if (pathCandidate) {
+    return { command: pathCandidate, source: 'path', envPath: pathValue };
+  }
+
+  throw new Error(
+    `Could not resolve a local gbrain executable.\n` +
+    `The Codex GBrain plugin is an adapter over a local GBrain install.\n` +
+    `Tried, in order:\n` +
+    `  1. GBRAIN_CODEX_BIN\n` +
+    `  2. ${repoCandidate}\n` +
+    `  3. gbrain on PATH (with $HOME/.bun/bin prepended)\n` +
+    `Fix one of these and try again. Typical local setup is:\n` +
+    `  bun install && bun run build && bun link`,
+  );
+}
+
+export async function main(argv = process.argv.slice(2), env = process.env) {
+  const resolved = resolveGbrainExecutable({ pluginRoot: PLUGIN_ROOT, env });
+  const gbrainHome = resolveGbrainHome(env);
+  const child = spawn(resolved.command, buildServeArgs(argv), {
+    cwd: process.cwd(),
+    env: {
+      ...env,
+      ...(gbrainHome ? { GBRAIN_HOME: gbrainHome } : {}),
+      PATH: resolved.envPath,
+    },
+    stdio: 'inherit',
+  });
+
+  child.on('error', err => {
+    process.stderr.write(`[gbrain-codex] failed to launch gbrain: ${err.message}\n`);
+    process.exit(1);
+  });
+
+  child.on('exit', (code, signal) => {
+    if (signal) process.kill(process.pid, signal);
+    process.exit(code ?? 0);
+  });
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === SCRIPT_PATH) {
+  main().catch(err => {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  });
+}

--- a/plugins/gbrain-codex/scripts/rehearsal.mjs
+++ b/plugins/gbrain-codex/scripts/rehearsal.mjs
@@ -1,0 +1,184 @@
+import { spawnSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+import { resolveGbrainExecutable } from './launch-gbrain-serve.mjs';
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const PLUGIN_ROOT = resolve(dirname(SCRIPT_PATH), '..');
+const REPO_ROOT = resolve(PLUGIN_ROOT, '..', '..');
+
+function textContent(result) {
+  const first = Array.isArray(result?.content) ? result.content[0] : null;
+  return first && first.type === 'text' ? first.text : '';
+}
+
+function runAndCapture(command, args, env) {
+  const result = spawnSync(command, args, {
+    env,
+    encoding: 'utf-8',
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `Command failed: ${command} ${args.join(' ')}\n` +
+      `${result.stderr || result.stdout || '(no output)'}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+function ensureTempBrain(command, env) {
+  runAndCapture(command, ['init', '--pglite', '--non-interactive', '--json'], env);
+}
+
+function expectedToolNames(command, env) {
+  const raw = runAndCapture(command, ['--tools-json'], env);
+  return JSON.parse(raw).map(tool => tool.name);
+}
+
+function createSourceTreeWrapper() {
+  const wrapperDir = mkdtempSync(join(tmpdir(), 'gbrain-codex-wrapper-'));
+  const wrapperPath = join(wrapperDir, 'gbrain');
+  writeFileSync(
+    wrapperPath,
+    `#!/bin/sh
+cd ${JSON.stringify(REPO_ROOT)}
+exec bun run src/cli.ts "$@"
+`,
+  );
+  chmodSync(wrapperPath, 0o755);
+  return { wrapperDir, wrapperPath };
+}
+
+export async function runRehearsal({ env = process.env } = {}) {
+  const wrapper = !env.GBRAIN_CODEX_BIN ? createSourceTreeWrapper() : null;
+  const resolvedEnv = wrapper
+    ? { ...env, GBRAIN_CODEX_BIN: wrapper.wrapperPath }
+    : env;
+  const resolvedBin = resolveGbrainExecutable({ pluginRoot: PLUGIN_ROOT, env: resolvedEnv });
+  const rehearsalHome = mkdtempSync(join(tmpdir(), 'gbrain-codex-home-'));
+  const runtimeEnv = {
+    ...resolvedEnv,
+    PATH: resolvedBin.envPath,
+    GBRAIN_HOME: rehearsalHome,
+  };
+
+  try {
+    ensureTempBrain(resolvedBin.command, runtimeEnv);
+    const expectedNames = expectedToolNames(resolvedBin.command, runtimeEnv);
+
+    const transport = new StdioClientTransport({
+      command: 'node',
+      args: ['./scripts/launch-gbrain-serve.mjs'],
+      cwd: PLUGIN_ROOT,
+      env: runtimeEnv,
+      stderr: 'pipe',
+    });
+    const client = new Client(
+      { name: 'gbrain-codex-rehearsal', version: '1.0.0' },
+      { capabilities: {} },
+    );
+
+    const stderrLines = [];
+    if (transport.stderr) {
+      transport.stderr.on('data', chunk => stderrLines.push(String(chunk)));
+    }
+
+    await client.connect(transport);
+    try {
+      const listed = await client.listTools();
+      const actualNames = listed.tools.map(tool => tool.name);
+      if (actualNames.length !== expectedNames.length) {
+        throw new Error(`tools/list count mismatch: expected ${expectedNames.length}, got ${actualNames.length}`);
+      }
+      if (JSON.stringify(actualNames) !== JSON.stringify(expectedNames)) {
+        throw new Error('tools/list names do not match gbrain --tools-json exactly');
+      }
+
+      const put = await client.callTool({
+        name: 'put_page',
+        arguments: {
+          slug: 'notes/codex-plugin-rehearsal',
+          content: [
+            '---',
+            'title: Codex Plugin Rehearsal',
+            'type: note',
+            '---',
+            '',
+            'Codex plugin rehearsal page.',
+          ].join('\n'),
+        },
+      });
+      if (put.isError) throw new Error(`put_page failed: ${textContent(put)}`);
+
+      const get = await client.callTool({
+        name: 'get_page',
+        arguments: { slug: 'notes/codex-plugin-rehearsal' },
+      });
+      if (get.isError || !textContent(get).includes('codex-plugin-rehearsal')) {
+        throw new Error(`get_page failed: ${textContent(get)}`);
+      }
+
+      const search = await client.callTool({
+        name: 'search',
+        arguments: { query: 'Codex plugin rehearsal page' },
+      });
+      if (search.isError) throw new Error(`search failed: ${textContent(search)}`);
+
+      const query = await client.callTool({
+        name: 'query',
+        arguments: { query: 'What page mentions Codex plugin rehearsal?' },
+      });
+      if (query.isError) throw new Error(`query failed: ${textContent(query)}`);
+
+      const sync = await client.callTool({
+        name: 'sync_brain',
+        arguments: {
+          repo: REPO_ROOT,
+          dry_run: true,
+          no_pull: true,
+          no_embed: true,
+        },
+      });
+      if (sync.isError) throw new Error(`sync_brain dry-run failed: ${textContent(sync)}`);
+
+      const whoami = await client.callTool({
+        name: 'whoami',
+        arguments: {},
+      });
+      if (!whoami.isError || !textContent(whoami).includes('unknown_transport')) {
+        throw new Error(`whoami should fail closed over stdio MCP, got: ${textContent(whoami)}`);
+      }
+
+      return {
+        ok: true,
+        toolCount: actualNames.length,
+        sampleTools: ['put_page', 'get_page', 'search', 'query', 'sync_brain', 'whoami'],
+        stderr: stderrLines.join('').trim(),
+      };
+    } finally {
+      try {
+        await client.close();
+      } catch {
+        // best-effort
+      }
+    }
+  } finally {
+    rmSync(rehearsalHome, { recursive: true, force: true });
+    if (wrapper) rmSync(wrapper.wrapperDir, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === SCRIPT_PATH) {
+  runRehearsal().then(result => {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  }).catch(err => {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/install-codex-plugin.mjs
+++ b/scripts/install-codex-plugin.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(SCRIPT_PATH), '..');
+
+function usage() {
+  process.stdout.write(`Usage: node scripts/install-codex-plugin.mjs [options]
+
+Installs or updates the repo-owned gbrain-codex plugin for Codex Desktop by
+creating ~/plugins/gbrain-codex and updating ~/.agents/plugins/marketplace.json.
+
+Options:
+  --repo-dir <path>       Eva Brain checkout root (default: current repo)
+  --home <path>           Home directory to update (default: $HOME)
+  --dry-run               Print intended actions without writing
+  --force                 Replace an existing non-Eva gbrain-codex directory
+  -h, --help              Show this help
+`);
+}
+
+function parseArgs(argv) {
+  const opts = {
+    repoDir: REPO_ROOT,
+    home: process.env.HOME || '',
+    dryRun: false,
+    force: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--repo-dir') opts.repoDir = resolve(argv[++i] || '');
+    else if (arg === '--home') opts.home = resolve(argv[++i] || '');
+    else if (arg === '--dry-run') opts.dryRun = true;
+    else if (arg === '--force') opts.force = true;
+    else if (arg === '-h' || arg === '--help') {
+      usage();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  if (!opts.home) throw new Error('Could not resolve home directory. Pass --home <path>.');
+  return opts;
+}
+
+function log(message) {
+  process.stderr.write(`[gbrain-codex:install] ${message}\n`);
+}
+
+function runStep(opts, message, fn) {
+  log(message);
+  if (!opts.dryRun) fn();
+}
+
+function assertRepoShape(repoDir) {
+  const pluginRoot = join(repoDir, 'plugins', 'gbrain-codex');
+  const manifest = join(pluginRoot, '.codex-plugin', 'plugin.json');
+  const mcp = join(pluginRoot, '.mcp.json');
+  const skills = join(repoDir, 'skills');
+  for (const path of [manifest, mcp, skills]) {
+    if (!existsSync(path)) throw new Error(`Required path is missing: ${path}`);
+  }
+  const parsed = JSON.parse(readFileSync(manifest, 'utf8'));
+  if (parsed.name !== 'gbrain-codex') {
+    throw new Error(`Unexpected Codex plugin name in ${manifest}: ${parsed.name}`);
+  }
+  return { pluginRoot, manifest, mcp, skills };
+}
+
+function safeRemovePluginDir(pluginDir, force) {
+  if (!existsSync(pluginDir)) return;
+  const stat = lstatSync(pluginDir);
+  if (stat.isSymbolicLink()) {
+    rmSync(pluginDir, { force: true });
+    return;
+  }
+
+  const manifest = join(pluginDir, '.codex-plugin', 'plugin.json');
+  if (!force && existsSync(manifest)) {
+    try {
+      const parsed = JSON.parse(readFileSync(manifest, 'utf8'));
+      if (parsed.name === 'gbrain-codex') {
+        rmSync(pluginDir, { recursive: true, force: true });
+        return;
+      }
+    } catch {
+      // Fall through to the guarded error below.
+    }
+  }
+
+  if (!force) {
+    throw new Error(
+      `Refusing to replace existing plugin directory: ${pluginDir}\n` +
+      `Pass --force if this directory is safe to replace.`,
+    );
+  }
+  rmSync(pluginDir, { recursive: true, force: true });
+}
+
+function linkEntry(src, dest) {
+  mkdirSync(dirname(dest), { recursive: true });
+  symlinkSync(src, dest);
+}
+
+function installPluginTree(opts, paths) {
+  const pluginsDir = join(opts.home, 'plugins');
+  const pluginDir = join(pluginsDir, 'gbrain-codex');
+  runStep(opts, `Installing Codex plugin into ${pluginDir}`, () => {
+    mkdirSync(pluginsDir, { recursive: true });
+    safeRemovePluginDir(pluginDir, opts.force);
+    mkdirSync(pluginDir, { recursive: true });
+    linkEntry(join(paths.pluginRoot, '.codex-plugin'), join(pluginDir, '.codex-plugin'));
+    linkEntry(join(paths.pluginRoot, '.mcp.json'), join(pluginDir, '.mcp.json'));
+    linkEntry(join(paths.pluginRoot, 'README.md'), join(pluginDir, 'README.md'));
+    linkEntry(join(paths.pluginRoot, 'assets'), join(pluginDir, 'assets'));
+    linkEntry(join(paths.pluginRoot, 'scripts'), join(pluginDir, 'scripts'));
+    linkEntry(paths.skills, join(pluginDir, 'skills'));
+  });
+  return pluginDir;
+}
+
+function marketplacePath(home) {
+  return join(home, '.agents', 'plugins', 'marketplace.json');
+}
+
+function updateMarketplace(opts) {
+  const path = marketplacePath(opts.home);
+  runStep(opts, `Updating Codex marketplace ${path}`, () => {
+    mkdirSync(dirname(path), { recursive: true });
+    let doc = { name: 'local', interface: { displayName: 'Local Plugins' }, plugins: [] };
+    if (existsSync(path)) {
+      doc = JSON.parse(readFileSync(path, 'utf8'));
+    }
+    if (!Array.isArray(doc.plugins)) doc.plugins = [];
+    doc.name = doc.name || 'local';
+    doc.interface = doc.interface || { displayName: 'Local Plugins' };
+    doc.interface.displayName = doc.interface.displayName || 'Local Plugins';
+    const entry = {
+      name: 'gbrain-codex',
+      source: { source: 'local', path: './plugins/gbrain-codex' },
+      policy: { installation: 'AVAILABLE', authentication: 'ON_INSTALL' },
+      category: 'Engineering',
+    };
+    const idx = doc.plugins.findIndex(plugin => plugin && plugin.name === entry.name);
+    if (idx >= 0) doc.plugins[idx] = { ...doc.plugins[idx], ...entry };
+    else doc.plugins.push(entry);
+    writeFileSync(path, `${JSON.stringify(doc, null, 2)}\n`);
+  });
+  return path;
+}
+
+export function installCodexPlugin(argv = process.argv.slice(2)) {
+  const opts = parseArgs(argv);
+  const paths = assertRepoShape(opts.repoDir);
+  const pluginDir = installPluginTree(opts, paths);
+  const market = updateMarketplace(opts);
+  const rel = relative(opts.home, pluginDir) || pluginDir;
+  log(`Installed ${rel}; restart Codex Desktop to reload plugins.`);
+  return { pluginDir, marketplace: market, dryRun: opts.dryRun };
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === SCRIPT_PATH) {
+  try {
+    const result = installCodexPlugin();
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
+  }
+}

--- a/scripts/install-codex-plugin.mjs
+++ b/scripts/install-codex-plugin.mjs
@@ -22,6 +22,13 @@ Options:
 }
 
 function parseArgs(argv) {
+  const requireValue = (flag, value) => {
+    if (!value || value.startsWith('-')) {
+      throw new Error(`Missing value for ${flag}`);
+    }
+    return value;
+  };
+
   const opts = {
     repoDir: REPO_ROOT,
     home: process.env.HOME || '',
@@ -30,8 +37,8 @@ function parseArgs(argv) {
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
-    if (arg === '--repo-dir') opts.repoDir = resolve(argv[++i] || '');
-    else if (arg === '--home') opts.home = resolve(argv[++i] || '');
+    if (arg === '--repo-dir') opts.repoDir = resolve(requireValue('--repo-dir', argv[++i]));
+    else if (arg === '--home') opts.home = resolve(requireValue('--home', argv[++i]));
     else if (arg === '--dry-run') opts.dryRun = true;
     else if (arg === '--force') opts.force = true;
     else if (arg === '-h' || arg === '--help') {

--- a/scripts/install-codex-plugin.mjs
+++ b/scripts/install-codex-plugin.mjs
@@ -70,8 +70,13 @@ function assertRepoShape(repoDir) {
 }
 
 function safeRemovePluginDir(pluginDir, force) {
-  if (!existsSync(pluginDir)) return;
-  const stat = lstatSync(pluginDir);
+  let stat;
+  try {
+    stat = lstatSync(pluginDir);
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') return;
+    throw error;
+  }
   if (stat.isSymbolicLink()) {
     rmSync(pluginDir, { force: true });
     return;

--- a/scripts/update-local-install.sh
+++ b/scripts/update-local-install.sh
@@ -103,8 +103,12 @@ checkout_repo() {
       die "Checkout is dirty. Commit/stash changes or pass --allow-dirty."
     fi
     run git -C "$INSTALL_DIR" fetch origin "$REF"
-    run git -C "$INSTALL_DIR" switch "$REF"
-    run git -C "$INSTALL_DIR" pull --ff-only origin "$REF"
+    if git -C "$INSTALL_DIR" rev-parse --verify --quiet "refs/heads/$REF" >/dev/null; then
+      run git -C "$INSTALL_DIR" switch "$REF"
+      run git -C "$INSTALL_DIR" pull --ff-only origin "$REF"
+    else
+      run git -C "$INSTALL_DIR" switch --detach FETCH_HEAD
+    fi
   elif [ -e "$INSTALL_DIR" ]; then
     die "Install dir exists but is not a git checkout: $INSTALL_DIR"
   else

--- a/scripts/update-local-install.sh
+++ b/scripts/update-local-install.sh
@@ -4,7 +4,12 @@ set -euo pipefail
 REPO_URL="${EVA_BRAIN_REPO_URL:-https://github.com/electricsheephq/eva-brain.git}"
 INSTALL_DIR="${EVA_BRAIN_DIR:-$HOME/eva-brain}"
 REF="${EVA_BRAIN_REF:-master}"
-GBRAIN_PARENT="${GBRAIN_HOME:-$HOME}"
+GBRAIN_ROOT="${GBRAIN_HOME:-$HOME}"
+if [ "${GBRAIN_ROOT%/.gbrain}" != "$GBRAIN_ROOT" ]; then
+  GBRAIN_ROOT="$(dirname "$GBRAIN_ROOT")"
+  export GBRAIN_HOME="$GBRAIN_ROOT"
+fi
+GBRAIN_DIR="$GBRAIN_ROOT/.gbrain"
 WITH_OPENCLAW="auto"
 WITH_CODEX_PLUGIN="auto"
 WITH_SUPPORT_KB="false"
@@ -42,7 +47,8 @@ Environment:
   VOYAGE_API_KEY               Used by gbrain provider probes and embeddings
   EVA_BRAIN_DIR                Same as --dir
   EVA_BRAIN_REF                Same as --ref
-  GBRAIN_HOME                  Parent for ~/.gbrain runtime data
+  GBRAIN_HOME                  Parent for .gbrain runtime data. If it points
+                               directly at a .gbrain dir, the updater normalizes it.
 
 Examples:
   scripts/update-local-install.sh
@@ -129,7 +135,7 @@ install_gbrain() {
   export PATH="$HOME/.bun/bin:$PATH"
   run bun install
   run bun link
-  local config_path="$GBRAIN_PARENT/.gbrain/config.json"
+  local config_path="$GBRAIN_DIR/config.json"
   if [ -f "$config_path" ]; then
     run "$HOME/.bun/bin/gbrain" init
   else
@@ -205,7 +211,7 @@ install_support_kb() {
   need_cmd git
   need_cmd node
   local kb_repo="${OPENCLAW_SUPPORT_KB_REPO:-https://github.com/electricsheephq/openclaw-support-kb.git}"
-  local kb_dir="${OPENCLAW_SUPPORT_KB_DIR:-$GBRAIN_PARENT/.gbrain/sources/openclaw-support-kb}"
+  local kb_dir="${OPENCLAW_SUPPORT_KB_DIR:-$GBRAIN_DIR/sources/openclaw-support-kb}"
   if [ -d "$kb_dir/.git" ]; then
     run git -C "$kb_dir" pull --ff-only
   else

--- a/scripts/update-local-install.sh
+++ b/scripts/update-local-install.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_URL="${EVA_BRAIN_REPO_URL:-https://github.com/electricsheephq/eva-brain.git}"
+INSTALL_DIR="${EVA_BRAIN_DIR:-$HOME/eva-brain}"
+REF="${EVA_BRAIN_REF:-master}"
+GBRAIN_PARENT="${GBRAIN_HOME:-$HOME}"
+WITH_OPENCLAW="auto"
+WITH_CODEX_PLUGIN="auto"
+WITH_SUPPORT_KB="false"
+RUN_DOCTOR="true"
+RUN_PROVIDER_TEST="auto"
+STOP_STALE_SERVE="false"
+DRY_RUN="false"
+ALLOW_DIRTY="false"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/update-local-install.sh [options]
+
+Public local updater for Eva Brain/GBrain. It clones or fast-forwards a checkout,
+installs dependencies, links the gbrain CLI, runs idempotent PGLite migrations,
+and optionally refreshes host plugins.
+
+Options:
+  --dir <path>                 Checkout/install directory (default: ~/eva-brain)
+  --repo <url>                 Git repo URL (default: electricsheephq/eva-brain)
+  --ref <branch-or-tag>        Git ref to checkout/pull (default: master)
+  --with-openclaw              Install/enable the OpenClaw native plugin
+  --without-openclaw           Skip OpenClaw plugin install
+  --with-codex-plugin          Install/update the Codex Desktop local plugin entry
+  --without-codex-plugin       Skip Codex plugin install
+  --with-support-kb            Install/update the OpenClaw Support KB source
+  --stop-stale-serve           Stop stale local gbrain serve processes before doctor
+  --skip-doctor                Skip gbrain doctor
+  --skip-provider-test         Skip provider probe
+  --allow-dirty                Allow updating a dirty existing checkout
+  --dry-run                    Print commands without mutating
+  -h, --help                   Show this help
+
+Environment:
+  VOYAGE_API_KEY               Used by gbrain provider probes and embeddings
+  EVA_BRAIN_DIR                Same as --dir
+  EVA_BRAIN_REF                Same as --ref
+  GBRAIN_HOME                  Parent for ~/.gbrain runtime data
+
+Examples:
+  scripts/update-local-install.sh
+  scripts/update-local-install.sh --with-openclaw --with-codex-plugin
+  scripts/update-local-install.sh --with-support-kb --stop-stale-serve
+USAGE
+}
+
+log() {
+  printf '[eva-brain:update] %s\n' "$*" >&2
+}
+
+die() {
+  printf '[eva-brain:update] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+run() {
+  printf '+'
+  printf ' %q' "$@"
+  printf '\n'
+  if [ "$DRY_RUN" = "false" ]; then
+    "$@"
+  fi
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+}
+
+parse_args() {
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --dir) INSTALL_DIR="${2:?missing value for --dir}"; shift 2 ;;
+      --repo) REPO_URL="${2:?missing value for --repo}"; shift 2 ;;
+      --ref) REF="${2:?missing value for --ref}"; shift 2 ;;
+      --with-openclaw) WITH_OPENCLAW="true"; shift ;;
+      --without-openclaw) WITH_OPENCLAW="false"; shift ;;
+      --with-codex-plugin) WITH_CODEX_PLUGIN="true"; shift ;;
+      --without-codex-plugin) WITH_CODEX_PLUGIN="false"; shift ;;
+      --with-support-kb) WITH_SUPPORT_KB="true"; shift ;;
+      --stop-stale-serve) STOP_STALE_SERVE="true"; shift ;;
+      --skip-doctor) RUN_DOCTOR="false"; shift ;;
+      --skip-provider-test) RUN_PROVIDER_TEST="false"; shift ;;
+      --allow-dirty) ALLOW_DIRTY="true"; shift ;;
+      --dry-run) DRY_RUN="true"; shift ;;
+      -h|--help) usage; exit 0 ;;
+      *) die "Unknown option: $1" ;;
+    esac
+  done
+}
+
+checkout_repo() {
+  need_cmd git
+  if git -C "$INSTALL_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    log "Updating checkout: $INSTALL_DIR"
+    if [ "$ALLOW_DIRTY" = "false" ] && [ -n "$(git -C "$INSTALL_DIR" status --porcelain)" ]; then
+      die "Checkout is dirty. Commit/stash changes or pass --allow-dirty."
+    fi
+    run git -C "$INSTALL_DIR" fetch origin "$REF"
+    run git -C "$INSTALL_DIR" switch "$REF"
+    run git -C "$INSTALL_DIR" pull --ff-only origin "$REF"
+  elif [ -e "$INSTALL_DIR" ]; then
+    die "Install dir exists but is not a git checkout: $INSTALL_DIR"
+  else
+    log "Cloning $REPO_URL into $INSTALL_DIR"
+    run git clone --branch "$REF" "$REPO_URL" "$INSTALL_DIR"
+  fi
+}
+
+ensure_bun() {
+  if command -v bun >/dev/null 2>&1; then
+    return
+  fi
+  die "Bun is required. Install it from https://bun.sh, then rerun this script."
+}
+
+install_gbrain() {
+  ensure_bun
+  export PATH="$HOME/.bun/bin:$PATH"
+  run bun install
+  run bun link
+  local config_path="$GBRAIN_PARENT/.gbrain/config.json"
+  if [ -f "$config_path" ]; then
+    run "$HOME/.bun/bin/gbrain" init
+  else
+    run "$HOME/.bun/bin/gbrain" init --pglite --embedding-model voyage:voyage-4-large --embedding-dimensions 2048
+  fi
+}
+
+stop_stale_serve_if_requested() {
+  if [ "$STOP_STALE_SERVE" != "true" ]; then
+    return
+  fi
+  if pgrep -f 'gbrain serve' >/dev/null 2>&1; then
+    log "Stopping stale gbrain serve processes before local PGLite doctor"
+    run pkill -f 'gbrain serve'
+    sleep 1
+  fi
+}
+
+doctor() {
+  if [ "$RUN_DOCTOR" != "true" ]; then
+    return
+  fi
+  stop_stale_serve_if_requested
+  run "$HOME/.bun/bin/gbrain" doctor --json
+}
+
+provider_test() {
+  if [ "$RUN_PROVIDER_TEST" = "false" ]; then
+    return
+  fi
+  if [ "${RUN_PROVIDER_TEST}" = "auto" ] && [ -z "${VOYAGE_API_KEY:-}" ]; then
+    log "Skipping Voyage provider probe because VOYAGE_API_KEY is not set"
+    return
+  fi
+  run "$HOME/.bun/bin/gbrain" providers test --model voyage:voyage-4-large
+}
+
+install_openclaw_plugin() {
+  if [ "$WITH_OPENCLAW" = "auto" ] && ! command -v openclaw >/dev/null 2>&1; then
+    log "OpenClaw not found; skipping OpenClaw plugin install"
+    return
+  fi
+  if [ "$WITH_OPENCLAW" = "false" ]; then
+    return
+  fi
+  need_cmd openclaw
+  run openclaw plugins install --force --dangerously-force-unsafe-install ./plugins/openclaw-gbrain
+  run openclaw plugins enable gbrain
+  run openclaw gateway restart
+  run openclaw plugins inspect gbrain --runtime --json
+}
+
+install_codex_plugin() {
+  if [ "$WITH_CODEX_PLUGIN" = "auto" ] && [ ! -d "$HOME/.codex" ] && [ ! -d "$HOME/.agents" ]; then
+    log "Codex Desktop config dirs not found; skipping Codex plugin install"
+    return
+  fi
+  if [ "$WITH_CODEX_PLUGIN" = "false" ]; then
+    return
+  fi
+  need_cmd node
+  if [ "$DRY_RUN" = "true" ]; then
+    run node scripts/install-codex-plugin.mjs --dry-run
+  else
+    run node scripts/install-codex-plugin.mjs
+  fi
+}
+
+install_support_kb() {
+  if [ "$WITH_SUPPORT_KB" != "true" ]; then
+    return
+  fi
+  need_cmd git
+  need_cmd node
+  local kb_repo="${OPENCLAW_SUPPORT_KB_REPO:-https://github.com/electricsheephq/openclaw-support-kb.git}"
+  local kb_dir="${OPENCLAW_SUPPORT_KB_DIR:-$GBRAIN_PARENT/.gbrain/sources/openclaw-support-kb}"
+  if [ -d "$kb_dir/.git" ]; then
+    run git -C "$kb_dir" pull --ff-only
+  else
+    run mkdir -p "$(dirname "$kb_dir")"
+    run git clone "$kb_repo" "$kb_dir"
+  fi
+  run node "$kb_dir/scripts/update-client.mjs"
+  run node "$kb_dir/scripts/status.mjs"
+  run "$HOME/.bun/bin/gbrain" embed --stale --source openclaw-support-kb
+}
+
+main() {
+  parse_args "$@"
+  checkout_repo
+  cd "$INSTALL_DIR"
+  install_gbrain
+  install_openclaw_plugin
+  install_codex_plugin
+  install_support_kb
+  provider_test
+  doctor
+  log "Update complete."
+}
+
+main "$@"

--- a/skills/manifest.json
+++ b/skills/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "gbrain",
-  "version": "0.32.5",
+  "version": "0.33.0",
   "conformance_version": "1.0.0",
   "description": "Personal knowledge brain with hybrid RAG search \u2014 GStack mod for agent platforms",
   "skills": [

--- a/test/install-contract.test.ts
+++ b/test/install-contract.test.ts
@@ -27,7 +27,8 @@ describe('Eva Brain install contract', () => {
     expect(guide).toContain('/plugins/gbrain/extract');
     expect(guide).toContain('openclaw plugins install');
     expect(guide).toContain('OPENCLAW_SUPPORT_KB_REPO');
-    expect(guide).toContain('GBRAIN_PARENT="${GBRAIN_HOME:-$HOME}"');
+    expect(guide).toContain('GBRAIN_ROOT="${GBRAIN_HOME:-$HOME}"');
+    expect(guide).toContain('GBRAIN_ROOT/.gbrain/sources/openclaw-support-kb');
     expect(guide).toContain('https://github.com/electricsheephq/openclaw-support-kb.git');
     expect(guide).toContain('node scripts/update-client.mjs');
     expect(guide).toContain('node scripts/status.mjs');

--- a/test/local-updater-contract.test.ts
+++ b/test/local-updater-contract.test.ts
@@ -29,14 +29,17 @@ describe('public local updater and Codex plugin packaging', () => {
   test('update script is public-host phrased and syntax-valid', () => {
     const script = readFileSync(join(root, 'scripts/update-local-install.sh'), 'utf8');
 
-    expect(script).toContain('Usage: scripts/update-local-install.sh [options]');
-    expect(script).toContain('--with-openclaw');
-    expect(script).toContain('--with-codex-plugin');
-    expect(script).toContain('node scripts/install-codex-plugin.mjs');
-    expect(script).toContain('switch --detach FETCH_HEAD');
-    expect(script).toContain('init --pglite --embedding-model voyage:voyage-4-large --embedding-dimensions 2048');
-    expect(script).toContain('if [ -f "$config_path" ]; then');
-    expect(script).toContain('run "$HOME/.bun/bin/gbrain" init');
+    expect(script).toMatch(/Usage:\s+scripts\/update-local-install\.sh\s+\[options\]/);
+    expect(script).toMatch(/--with-openclaw\b/);
+    expect(script).toMatch(/--with-codex-plugin\b/);
+    expect(script).toMatch(/node\s+scripts\/install-codex-plugin\.mjs/);
+    expect(script).toMatch(/switch\s+--detach\s+FETCH_HEAD/);
+    expect(script).toMatch(/GBRAIN_ROOT="\$\{GBRAIN_HOME:-\$HOME\}"/);
+    expect(script).toMatch(/GBRAIN_DIR="\$GBRAIN_ROOT\/\.gbrain"/);
+    expect(script).toMatch(/config_path="\$GBRAIN_DIR\/config\.json"/);
+    expect(script).toMatch(/init\s+--pglite\s+--embedding-model\s+voyage:voyage-4-large\s+--embedding-dimensions\s+2048/);
+    expect(script).toMatch(/if \[ -f "\$config_path" \]; then/);
+    expect(script).toMatch(/run "\$HOME\/\.bun\/bin\/gbrain" init/);
     expect(script).not.toMatch(/\bfleet\b/i);
 
     const result = Bun.spawnSync({
@@ -123,5 +126,18 @@ describe('public local updater and Codex plugin packaging', () => {
     expect(result.exitCode).toBe(0);
     expect(existsSync(join(home, 'plugins/gbrain-codex'))).toBe(false);
     expect(existsSync(join(home, '.agents/plugins/marketplace.json'))).toBe(false);
+  });
+
+  test('Codex installer rejects missing option values instead of falling back to cwd', () => {
+    for (const flag of ['--home', '--repo-dir']) {
+      const result = Bun.spawnSync({
+        cmd: ['node', 'scripts/install-codex-plugin.mjs', flag],
+        cwd: root,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+      expect(result.exitCode).toBe(1);
+      expect(new TextDecoder().decode(result.stderr)).toContain(`Missing value for ${flag}`);
+    }
   });
 });

--- a/test/local-updater-contract.test.ts
+++ b/test/local-updater-contract.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { existsSync, lstatSync, mkdtempSync, readFileSync, readlinkSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const root = process.cwd();
+const tmpHomes: string[] = [];
+
+interface MarketplaceEntry {
+  name?: string;
+  source: { path: string };
+  policy: { installation: string; authentication: string };
+}
+
+afterEach(() => {
+  while (tmpHomes.length > 0) {
+    const dir = tmpHomes.pop()!;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempHome(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gbrain-codex-install-test-'));
+  tmpHomes.push(dir);
+  return dir;
+}
+
+describe('public local updater and Codex plugin packaging', () => {
+  test('update script is public-host phrased and syntax-valid', () => {
+    const script = readFileSync(join(root, 'scripts/update-local-install.sh'), 'utf8');
+
+    expect(script).toContain('Usage: scripts/update-local-install.sh [options]');
+    expect(script).toContain('--with-openclaw');
+    expect(script).toContain('--with-codex-plugin');
+    expect(script).toContain('node scripts/install-codex-plugin.mjs');
+    expect(script).toContain('init --pglite --embedding-model voyage:voyage-4-large --embedding-dimensions 2048');
+    expect(script).toContain('if [ -f "$config_path" ]; then');
+    expect(script).toContain('run "$HOME/.bun/bin/gbrain" init');
+    expect(script).not.toMatch(/\bfleet\b/i);
+
+    const result = Bun.spawnSync({
+      cmd: ['bash', '-n', 'scripts/update-local-install.sh'],
+      cwd: root,
+    });
+    expect(result.exitCode).toBe(0);
+  });
+
+  test('Codex plugin metadata stays repo-owned and version-aligned', () => {
+    const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+    const skillManifest = JSON.parse(readFileSync(join(root, 'skills/manifest.json'), 'utf8'));
+    const codexPlugin = JSON.parse(readFileSync(join(root, 'plugins/gbrain-codex/.codex-plugin/plugin.json'), 'utf8'));
+    const codexPkg = JSON.parse(readFileSync(join(root, 'plugins/gbrain-codex/package.json'), 'utf8'));
+
+    expect(codexPlugin.name).toBe('gbrain-codex');
+    expect(codexPlugin.version).toBe(pkg.version);
+    expect(codexPkg.version).toBe(pkg.version);
+    expect(skillManifest.version).toBe(pkg.version);
+    expect(codexPlugin.repository).toContain('electricsheephq/eva-brain');
+    expect(codexPlugin.skills).toBe('./skills/');
+    expect(codexPlugin.mcpServers).toBe('./.mcp.json');
+  });
+
+  test('Codex plugin is not an OpenClaw plugin child by accident', () => {
+    expect(existsSync(join(root, 'plugins/gbrain-codex/openclaw.plugin.json'))).toBe(false);
+
+    const mcp = JSON.parse(readFileSync(join(root, 'plugins/gbrain-codex/.mcp.json'), 'utf8'));
+    expect(mcp.mcpServers['gbrain-codex'].command).toBe('node');
+    expect(mcp.mcpServers['gbrain-codex'].args).toContain('./scripts/launch-gbrain-serve.mjs');
+  });
+
+  test('Codex installer creates a local plugin shell linked to current repo skills', () => {
+    const home = tempHome();
+    const result = Bun.spawnSync({
+      cmd: ['node', 'scripts/install-codex-plugin.mjs', '--home', home, '--repo-dir', root],
+      cwd: root,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    expect(result.exitCode).toBe(0);
+
+    const pluginDir = join(home, 'plugins/gbrain-codex');
+    expect(existsSync(join(pluginDir, '.codex-plugin/plugin.json'))).toBe(true);
+    expect(existsSync(join(pluginDir, '.mcp.json'))).toBe(true);
+    expect(lstatSync(join(pluginDir, 'skills')).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(pluginDir, 'skills'))).toBe(join(root, 'skills'));
+
+    const marketplace = JSON.parse(readFileSync(join(home, '.agents/plugins/marketplace.json'), 'utf8'));
+    const entry = marketplace.plugins.find((plugin: MarketplaceEntry) => plugin.name === 'gbrain-codex') as MarketplaceEntry | undefined;
+    expect(entry).toBeTruthy();
+    if (!entry) throw new Error('gbrain-codex marketplace entry missing');
+    expect(entry.source.path).toBe('./plugins/gbrain-codex');
+    expect(entry.policy.installation).toBe('AVAILABLE');
+    expect(entry.policy.authentication).toBe('ON_INSTALL');
+  });
+
+  test('Codex installer dry-run does not create home plugin files', () => {
+    const home = tempHome();
+    const result = Bun.spawnSync({
+      cmd: ['node', 'scripts/install-codex-plugin.mjs', '--home', home, '--repo-dir', root, '--dry-run'],
+      cwd: root,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(join(home, 'plugins/gbrain-codex'))).toBe(false);
+    expect(existsSync(join(home, '.agents/plugins/marketplace.json'))).toBe(false);
+  });
+});

--- a/test/local-updater-contract.test.ts
+++ b/test/local-updater-contract.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import { existsSync, lstatSync, mkdtempSync, readFileSync, readlinkSync, rmSync } from 'node:fs';
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readlinkSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -33,6 +33,7 @@ describe('public local updater and Codex plugin packaging', () => {
     expect(script).toContain('--with-openclaw');
     expect(script).toContain('--with-codex-plugin');
     expect(script).toContain('node scripts/install-codex-plugin.mjs');
+    expect(script).toContain('switch --detach FETCH_HEAD');
     expect(script).toContain('init --pglite --embedding-model voyage:voyage-4-large --embedding-dimensions 2048');
     expect(script).toContain('if [ -f "$config_path" ]; then');
     expect(script).toContain('run "$HOME/.bun/bin/gbrain" init');
@@ -91,6 +92,24 @@ describe('public local updater and Codex plugin packaging', () => {
     expect(entry.source.path).toBe('./plugins/gbrain-codex');
     expect(entry.policy.installation).toBe('AVAILABLE');
     expect(entry.policy.authentication).toBe('ON_INSTALL');
+  });
+
+  test('Codex installer replaces stale or broken local gbrain-codex symlinks', () => {
+    const home = tempHome();
+    const pluginDir = join(home, 'plugins/gbrain-codex');
+    mkdirSync(join(home, 'plugins'), { recursive: true });
+    symlinkSync('/path/that/does/not/exist', pluginDir);
+    expect(lstatSync(pluginDir).isSymbolicLink()).toBe(true);
+
+    const result = Bun.spawnSync({
+      cmd: ['node', 'scripts/install-codex-plugin.mjs', '--home', home, '--repo-dir', root],
+      cwd: root,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    expect(result.exitCode).toBe(0);
+    expect(lstatSync(pluginDir).isDirectory()).toBe(true);
+    expect(readlinkSync(join(pluginDir, 'skills'))).toBe(join(root, 'skills'));
   });
 
   test('Codex installer dry-run does not create home plugin files', () => {


### PR DESCRIPTION
## Why

The local v0.33 canary showed two practical rollout problems:

1. Updating Eva Brain was still a checklist, not a public, repeatable command users or agents could run.
2. The Codex Desktop GBrain plugin existed only in this machine's local Codex cache at `gbrain-codex/0.30.0`, so it was stale and not reproducible from the repo.

This PR makes both pieces repo-owned without changing GBrain core behavior. The updater is public-host phrased, and the Codex plugin remains a thin adapter over `gbrain serve` rather than a second runtime.

Closes #83.

## What Changed

- Added `scripts/update-local-install.sh`:
  - clones or fast-forwards the checkout
  - runs `bun install` and `bun link`
  - preserves existing GBrain config by running `gbrain init` for existing installs
  - creates new installs with PGLite + `voyage:voyage-4-large` + 2048 dimensions
  - optionally installs OpenClaw, Codex Desktop, and support-KB surfaces
  - includes dry-run, dirty-check, host auto-detect, stale `gbrain serve` cleanup, and branch/tag ref handling

- Added `scripts/install-codex-plugin.mjs`:
  - creates `~/plugins/gbrain-codex`
  - links the repo-owned Codex plugin package
  - links the live repo `skills/` tree instead of copying stale skills
  - updates `~/.agents/plugins/marketplace.json` idempotently
  - replaces stale or broken local `gbrain-codex` symlinks safely

- Added `plugins/gbrain-codex`:
  - `.codex-plugin/plugin.json`
  - `.mcp.json`
  - launcher for `gbrain serve`
  - stdio MCP rehearsal script
  - README and icon

- Updated docs and scripts:
  - `INSTALL_FOR_AGENTS.md` now points at the updater and Codex plugin install path
  - `README.md` mentions the public updater path
  - `llms-full.txt` was regenerated from the docs source
  - package scripts expose `install:codex-plugin` and `rehearse:codex-plugin`
  - `skills/manifest.json` version is aligned with root `package.json`

## Boundaries

- This does not add a new GBrain server or forked tool implementation.
- This does not make `plugins/gbrain-codex` an OpenClaw plugin. It intentionally has no `openclaw.plugin.json`.
- This does not copy the old local Codex cache skill tree. The installer links the current repo `skills/` tree so Codex does not drift behind the repo.
- This is a public installer/update path, not a fleet-specific deployment script.

## Validation

Local focused checks from `/Volumes/LEXAR/repos/eva-brain-worktrees/codex-updater-plugin`:

```bash
bash -n scripts/update-local-install.sh
node scripts/install-codex-plugin.mjs --dry-run --home /tmp/eva-brain-codex-plugin-dryrun --repo-dir "$PWD"
scripts/update-local-install.sh --dry-run --dir "$PWD" --with-codex-plugin --without-openclaw --skip-doctor --skip-provider-test --allow-dirty
node plugins/gbrain-codex/scripts/rehearsal.mjs
bun test test/local-updater-contract.test.ts test/install-contract.test.ts test/openclaw-gbrain-plugin-contract.test.ts
bun test test/build-llms.test.ts
bun run typecheck
git diff --check
```

Results:

- Codex plugin rehearsal passed over stdio MCP: `ok=true`, `toolCount=62`, sample tools included `put_page`, `get_page`, `search`, `query`, `sync_brain`, and `whoami`.
- Focused installer/OpenClaw tests: `19 pass`, `0 fail`, `121 expect() calls`.
- Generated docs test: `7 pass`, `0 fail`, `64 expect() calls`.
- `tsc --noEmit`: pass.
- `git diff --check`: pass.

Full broader validation runs in GitHub Actions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add Codex Desktop plugin with local MCP integration and automated install/rehearse tooling
  * Introduce an idempotent local updater to clone/update, configure, and initialize local installs

* **Documentation**
  * Revise agent/install and upgrade guides with step-by-step updater flow and plugin install instructions

* **Packaging**
  * Bump plugin and skills versions; add plugin manifest and marketplace registration support

* **Tests**
  * Add tests validating updater and plugin install/packaging behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/eva-brain/pull/84)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->