### PR TITLE
Fix local updater canary edge cases

### DIFF
--- a/scripts/update-local-install.sh
+++ b/scripts/update-local-install.sh
@@ -36,7 +36,7 @@ Options:
   --with-codex-plugin          Install/update the Codex Desktop local plugin entry
   --without-codex-plugin       Skip Codex plugin install
   --with-support-kb            Install/update the OpenClaw Support KB source
-  --stop-stale-serve           Stop stale local gbrain serve processes before doctor
+  --stop-stale-serve           Stop stale local gbrain serve processes before init/doctor
   --skip-doctor                Skip gbrain doctor
   --skip-provider-test         Skip provider probe
   --allow-dirty                Allow updating a dirty existing checkout
@@ -135,6 +135,7 @@ install_gbrain() {
   export PATH="$HOME/.bun/bin:$PATH"
   run bun install
   run bun link
+  stop_stale_serve_if_requested
   local config_path="$GBRAIN_DIR/config.json"
   if [ -f "$config_path" ]; then
     run "$HOME/.bun/bin/gbrain" init
@@ -148,7 +149,7 @@ stop_stale_serve_if_requested() {
     return
   fi
   if pgrep -f 'gbrain serve' >/dev/null 2>&1; then
-    log "Stopping stale gbrain serve processes before local PGLite doctor"
+    log "Stopping stale gbrain serve processes before local PGLite work"
     run pkill -f 'gbrain serve'
     sleep 1
   fi

--- a/src/commands/migrations/v0_32_2.ts
+++ b/src/commands/migrations/v0_32_2.ts
@@ -137,14 +137,34 @@ function isLocalPathDirty(localPath: string): boolean {
   try {
     const out = execFileSync('git', ['-C', localPath, 'status', '--porcelain'], {
       encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
       timeout: 10_000,
     });
     return out.trim().length > 0;
-  } catch {
+  } catch (err) {
     // Not a git repo OR git not on PATH → treat as "not dirty" (the
     // user opted out of git tracking, which is allowed). The fence
-    // writes are still atomic via .tmp + rename.
-    return false;
+    // writes are still atomic via .tmp + rename. Unknown git failures
+    // fail closed by bubbling up to Phase B.
+    const error = err as {
+      code?: unknown;
+      status?: unknown;
+      stderr?: unknown;
+      message?: unknown;
+    };
+    const code = typeof error.code === 'string' ? error.code : '';
+    const status = typeof error.status === 'number' ? error.status : undefined;
+    const stderr = Buffer.isBuffer(error.stderr)
+      ? error.stderr.toString('utf-8')
+      : typeof error.stderr === 'string'
+        ? error.stderr
+        : '';
+    const message = typeof error.message === 'string' ? error.message : '';
+    const text = `${message}\n${stderr}`;
+    if (code === 'ENOENT' || (status === 128 && /not a git repository/i.test(text))) {
+      return false;
+    }
+    throw err;
   }
 }
 
@@ -179,24 +199,6 @@ async function phaseBFenceFacts(
   }
 
   try {
-    // Look up all sources + their local_paths.
-    const sources = await engine.executeRaw<SourceLookup>(
-      `SELECT id, local_path FROM sources`,
-    );
-    const localPathById = new Map<string, string | null>();
-    for (const s of sources) localPathById.set(s.id, s.local_path);
-
-    // Dirty-tree refusal: check every source's local_path before writing.
-    for (const [id, localPath] of localPathById) {
-      if (localPath && isLocalPathDirty(localPath)) {
-        return {
-          name: 'fence_facts',
-          status: 'failed',
-          detail: `source "${id}" has uncommitted changes in ${localPath}. Commit or stash, then re-run.`,
-        };
-      }
-    }
-
     // Walk legacy rows in (source_id, entity_slug) groups for per-page
     // atomic writes.
     const legacy = await engine.executeRaw<LegacyFactRow>(
@@ -206,7 +208,6 @@ async function phaseBFenceFacts(
         WHERE row_num IS NULL
         ORDER BY source_id, entity_slug, id`,
     );
-
     const outcome: PhaseBOutcome = {
       scanned: legacy.length,
       fenced: 0,
@@ -215,6 +216,24 @@ async function phaseBFenceFacts(
       pages_touched: 0,
       failed_pages: [],
     };
+
+    if (legacy.length === 0) {
+      return {
+        name: 'fence_facts',
+        status: 'complete',
+        detail: `scanned=${outcome.scanned} fenced=${outcome.fenced} ` +
+          `pages=${outcome.pages_touched} skipped_no_entity=${outcome.skipped_no_entity} ` +
+          `skipped_no_local_path=${outcome.skipped_no_local_path}`,
+      };
+    }
+
+    // Look up sources after confirming there is legacy work. Dirty-tree
+    // refusal only applies to source worktrees that will actually be written.
+    const sources = await engine.executeRaw<SourceLookup>(
+      `SELECT id, local_path FROM sources`,
+    );
+    const localPathById = new Map<string, string | null>();
+    for (const s of sources) localPathById.set(s.id, s.local_path);
 
     // Group by (source_id, entity_slug) so each page's fence is updated
     // atomically with all its legacy rows.
@@ -233,6 +252,20 @@ async function phaseBFenceFacts(
       const list = groups.get(key) ?? [];
       list.push(row);
       groups.set(key, list);
+    }
+
+    const sourceIdsToCheck = new Set<string>();
+    for (const key of groups.keys()) sourceIdsToCheck.add(key.split('\0', 1)[0]);
+
+    for (const sourceId of sourceIdsToCheck) {
+      const localPath = localPathById.get(sourceId);
+      if (localPath && isLocalPathDirty(localPath)) {
+        return {
+          name: 'fence_facts',
+          status: 'failed',
+          detail: `source "${sourceId}" has uncommitted changes in ${localPath}. Commit or stash, then re-run.`,
+        };
+      }
     }
 
     for (const [key, group] of groups) {

--- a/test/local-updater-contract.test.ts
+++ b/test/local-updater-contract.test.ts
@@ -37,6 +37,7 @@ describe('public local updater and Codex plugin packaging', () => {
     expect(script).toMatch(/GBRAIN_ROOT="\$\{GBRAIN_HOME:-\$HOME\}"/);
     expect(script).toMatch(/GBRAIN_DIR="\$GBRAIN_ROOT\/\.gbrain"/);
     expect(script).toMatch(/config_path="\$GBRAIN_DIR\/config\.json"/);
+    expect(script).toMatch(/stop_stale_serve_if_requested\s*\n\s*local config_path="\$GBRAIN_DIR\/config\.json"/);
     expect(script).toMatch(/init\s+--pglite\s+--embedding-model\s+voyage:voyage-4-large\s+--embedding-dimensions\s+2048/);
     expect(script).toMatch(/if \[ -f "\$config_path" \]; then/);
     expect(script).toMatch(/run "\$HOME\/\.bun\/bin\/gbrain" init/);

--- a/test/migrations-v0_32_2.test.ts
+++ b/test/migrations-v0_32_2.test.ts
@@ -72,6 +72,17 @@ async function seedLegacyFact(input: {
   return r.rows[0].id;
 }
 
+function makeDirtyGitWorktree(dir: string): void {
+  const init = Bun.spawnSync({
+    cmd: ['git', 'init'],
+    cwd: dir,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  expect(init.exitCode).toBe(0);
+  writeFileSync(join(dir, 'uncommitted.md'), 'dirty', 'utf-8');
+}
+
 describe('phaseASchema', () => {
   test('passes when schema is at v51', async () => {
     // initSchema ran v51, so the version config + columns are set.
@@ -89,6 +100,19 @@ describe('phaseASchema', () => {
     const r = await __testing.phaseASchema(null, OPTS);
     expect(r.status).toBe('skipped');
     expect(r.detail).toBe('no_brain_configured');
+  });
+});
+
+describe('isLocalPathDirty', () => {
+  test('treats non-git source directories as untracked rather than dirty', () => {
+    expect(__testing.isLocalPathDirty(brainDir)).toBe(false);
+  });
+
+  test('fails closed on unexpected git probe errors', () => {
+    const notDirectory = join(brainDir, 'not-a-directory');
+    writeFileSync(notDirectory, 'file, not directory', 'utf-8');
+
+    expect(() => __testing.isLocalPathDirty(notDirectory)).toThrow();
   });
 });
 
@@ -235,6 +259,59 @@ describe('phaseBFenceFacts — happy path backfill', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const rows = await (engine as any).db.query('SELECT row_num FROM facts');
     expect(rows.rows[0].row_num).toBeNull();
+  });
+
+  test('does not refuse a dirty source when there are no legacy facts to write', async () => {
+    makeDirtyGitWorktree(brainDir);
+
+    const r = await __testing.phaseBFenceFacts(engine, OPTS);
+    expect(r.status).toBe('complete');
+    expect(r.detail).toContain('scanned=0');
+    expect(r.detail).toContain('fenced=0');
+  });
+
+  test('does not refuse a dirty source when all legacy facts are structurally unfenceable', async () => {
+    makeDirtyGitWorktree(brainDir);
+    await seedLegacyFact({ entity_slug: null, fact: 'Unparented claim' });
+
+    const r = await __testing.phaseBFenceFacts(engine, OPTS);
+    expect(r.status).toBe('complete');
+    expect(r.detail).toContain('skipped_no_entity=1');
+    expect(r.detail).toContain('fenced=0');
+  });
+
+  test('does not refuse a dirty source that has no fenceable writes in this migration', async () => {
+    const unusedDir = mkdtempSync(join(tmpdir(), 'mig-v0_32_2-unused-source-'));
+    try {
+      makeDirtyGitWorktree(unusedDir);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (engine as any).db.query(
+        `INSERT INTO sources (id, name, local_path, config)
+         VALUES ('unused-dirty', 'unused-dirty', $1, '{}'::jsonb)
+         ON CONFLICT (id) DO UPDATE SET local_path = excluded.local_path`,
+        [unusedDir],
+      );
+      await seedLegacyFact({ entity_slug: 'people/alice', fact: 'Default source write only' });
+
+      const r = await __testing.phaseBFenceFacts(engine, OPTS);
+      expect(r.status).toBe('complete');
+      expect(r.detail).toContain('fenced=1');
+      expect(existsSync(join(brainDir, 'people/alice.md'))).toBe(true);
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (engine as any).db.query(`DELETE FROM sources WHERE id = 'unused-dirty'`);
+      rmSync(unusedDir, { recursive: true, force: true });
+    }
+  });
+
+  test('still refuses a dirty source before writing fenceable facts', async () => {
+    makeDirtyGitWorktree(brainDir);
+    await seedLegacyFact({ entity_slug: 'people/alice', fact: 'Needs a fenced write' });
+
+    const r = await __testing.phaseBFenceFacts(engine, OPTS);
+    expect(r.status).toBe('failed');
+    expect(r.detail).toContain('source "default" has uncommitted changes');
+    expect(existsSync(join(brainDir, 'people/alice.md'))).toBe(false);
   });
 });
 


### PR DESCRIPTION
Closes #85.

## Why

The repo-owned updater and Codex plugin from #84 installed cleanly, but the local canary exposed two setup edges that would make a fresh public install feel broken:

1. `--stop-stale-serve` only stopped stale `gbrain serve` processes before `doctor`, so `gbrain init` / migration-sensitive setup could still hit a locked PGLite database.
2. The v0.32.2 facts-fence migration refused any dirty source worktree before it checked whether it had facts to write. On a real local brain with zero legacy facts, that turned a no-op migration into a blocker because an unrelated workspace source had uncommitted files.

## What Changed

- Moves the updater's stale-server stop before `gbrain init` while keeping the doctor protection idempotent.
- Changes v0.32.2 facts backfill to query legacy facts first, group only fenceable rows, and dirty-check only source worktrees that will actually be written.
- Keeps the safety rule intact: if a source has fenceable legacy facts and its worktree is dirty, the migration still fails before writing.
- Suppresses expected `git status` stderr for non-git source folders, which are allowed by design.

## Validation

Local focused validation from `/Volumes/LEXAR/repos/eva-brain`:

```bash
bash -n scripts/update-local-install.sh
bun test test/local-updater-contract.test.ts test/migrations-v0_32_2.test.ts
bun run typecheck
git diff --check
```

All passed locally. Full-suite validation should run in GitHub Actions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stale local serve processes are now stopped earlier—before init/config work.
  * Migration fencing avoids unnecessary filesystem checks and treats non-git directories as not-dirty; better handling of unexpected git probe errors.

* **Tests**
  * Expanded coverage for installation and migration scenarios, including dirty-worktree behaviors and the new stop-stale behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/eva-brain/pull/86)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->