### PR TITLE
docs: clarify Eva host plugin install paths

### DIFF
--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -32,6 +32,25 @@ plugins when those hosts are present.
 To require host plugin setup instead of auto-detecting it, pass
 `--with-openclaw` and/or `--with-codex-plugin`.
 
+Full Eva/OpenClaw/Codex/support-KB install:
+
+```bash
+git clone https://github.com/electricsheephq/eva-brain.git ~/eva-brain
+cd ~/eva-brain
+scripts/update-local-install.sh --with-openclaw --with-codex-plugin --with-support-kb --stop-stale-serve
+```
+
+What that command does:
+
+- installs or updates the local `gbrain` CLI from this checkout
+- initializes PGLite if no brain exists yet
+- keeps existing local brain data under `~/.gbrain`
+- installs the OpenClaw native plugin from `plugins/openclaw-gbrain`
+- installs the Codex Desktop plugin from `plugins/gbrain-codex`
+- installs or updates the OpenClaw support KB as source `openclaw-support-kb`
+- embeds only stale chunks for that KB source
+- runs provider probe and `gbrain doctor` when possible
+
 Manual path:
 
 ```bash
@@ -110,6 +129,11 @@ The plugin provides:
 - `gbrain_query`
 - `/plugins/gbrain/extract` for OAuth-backed extraction through OpenClaw/Codex
 
+What is different from normal GBrain: normal GBrain exposes CLI and MCP tools.
+The OpenClaw plugin lets OpenClaw agents call those tools natively and adds a
+host-owned extraction route. That route uses OpenClaw's logged-in Codex runtime;
+users do not need an OpenAI API key for extraction.
+
 Media boundary: upstream GBrain owns native image indexing through image pages,
 file records, multimodal embeddings, OCR, and `query --image`. Eva's OpenClaw
 plugin owns OAuth-backed enrichment/extraction and returns
@@ -137,6 +161,10 @@ updates `~/.agents/plugins/marketplace.json`.
 The plugin is a thin MCP adapter over the local `gbrain` CLI. It does not embed
 a second brain runtime. If Codex cannot see `gbrain` on the GUI PATH, set
 `GBRAIN_CODEX_BIN` to the desired executable path before launching Codex.
+
+What is different from normal GBrain: normal GBrain can already be configured as
+an MCP server manually. The Codex plugin packages that MCP launch path in a
+repo-owned plugin directory so agents can install it repeatably with one script.
 
 ## Step 3.7: Install The OpenClaw Support KB
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,15 @@ GBrain, sets up a Voyage 4 Large 2048d brain when `VOYAGE_API_KEY` is available,
 installs host plugins such as OpenClaw and Codex Desktop when those hosts are
 present, and verifies the local doctor score. ~30 minutes.
 
-For manual installs or upgrades from an existing checkout:
+For a full local OpenClaw/Codex/support-KB install from a shell:
+
+```bash
+git clone https://github.com/electricsheephq/eva-brain.git ~/eva-brain
+cd ~/eva-brain
+scripts/update-local-install.sh --with-openclaw --with-codex-plugin --with-support-kb --stop-stale-serve
+```
+
+For manual upgrades from an existing checkout:
 
 ```bash
 cd ~/eva-brain
@@ -49,7 +57,29 @@ scripts/update-local-install.sh
 ```
 
 Use `--with-openclaw` or `--with-codex-plugin` when you want the script to fail
-instead of auto-skipping a missing host.
+instead of auto-skipping a missing host. Use `--with-support-kb` to install or
+refresh the OpenClaw support knowledge base as a named GBrain source.
+
+### What Eva Adds
+
+Eva Brain tracks upstream GBrain closely. The downstream additions are the host
+and install surfaces our users need:
+
+- **OpenClaw native plugin:** `plugins/openclaw-gbrain` adds GBrain tools and
+  `/plugins/gbrain/extract`, using OpenClaw's logged-in Codex runtime for
+  extraction instead of asking users for an OpenAI API key.
+- **Codex Desktop plugin:** `plugins/gbrain-codex` is a thin local MCP package
+  that launches the installed `gbrain serve` for Codex Desktop.
+- **One-command updater:** `scripts/update-local-install.sh` safely updates the
+  checkout, links the CLI, runs idempotent local init/migrations, and optionally
+  refreshes host plugins and the support KB.
+- **Opinionated defaults:** Voyage 4 Large at 2048 dimensions for technical
+  workspaces, `~/.gbrain/gbrain.env` support, and safe local install behavior.
+
+Upstream GBrain still owns the database, search, sync, graph, facts, native
+media, provider recipes, and MCP core. Eva's media extraction schema is an
+adapter payload for host runtimes; it is not intended to replace upstream's
+native image/file/media storage model.
 
 For provider choice, embedding dimensions, Voyage 4 Large 2048d setup, and the OpenClaw Codex OAuth extraction boundary, read [`docs/guides/provider-install-matrix.md`](docs/guides/provider-install-matrix.md).
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1586,6 +1586,25 @@ plugins when those hosts are present.
 To require host plugin setup instead of auto-detecting it, pass
 `--with-openclaw` and/or `--with-codex-plugin`.
 
+Full Eva/OpenClaw/Codex/support-KB install:
+
+```bash
+git clone https://github.com/electricsheephq/eva-brain.git ~/eva-brain
+cd ~/eva-brain
+scripts/update-local-install.sh --with-openclaw --with-codex-plugin --with-support-kb --stop-stale-serve
+```
+
+What that command does:
+
+- installs or updates the local `gbrain` CLI from this checkout
+- initializes PGLite if no brain exists yet
+- keeps existing local brain data under `~/.gbrain`
+- installs the OpenClaw native plugin from `plugins/openclaw-gbrain`
+- installs the Codex Desktop plugin from `plugins/gbrain-codex`
+- installs or updates the OpenClaw support KB as source `openclaw-support-kb`
+- embeds only stale chunks for that KB source
+- runs provider probe and `gbrain doctor` when possible
+
 Manual path:
 
 ```bash
@@ -1664,6 +1683,11 @@ The plugin provides:
 - `gbrain_query`
 - `/plugins/gbrain/extract` for OAuth-backed extraction through OpenClaw/Codex
 
+What is different from normal GBrain: normal GBrain exposes CLI and MCP tools.
+The OpenClaw plugin lets OpenClaw agents call those tools natively and adds a
+host-owned extraction route. That route uses OpenClaw's logged-in Codex runtime;
+users do not need an OpenAI API key for extraction.
+
 Media boundary: upstream GBrain owns native image indexing through image pages,
 file records, multimodal embeddings, OCR, and `query --image`. Eva's OpenClaw
 plugin owns OAuth-backed enrichment/extraction and returns
@@ -1691,6 +1715,10 @@ updates `~/.agents/plugins/marketplace.json`.
 The plugin is a thin MCP adapter over the local `gbrain` CLI. It does not embed
 a second brain runtime. If Codex cannot see `gbrain` on the GUI PATH, set
 `GBRAIN_CODEX_BIN` to the desired executable path before launching Codex.
+
+What is different from normal GBrain: normal GBrain can already be configured as
+an MCP server manually. The Codex plugin packages that MCP launch path in a
+repo-owned plugin directory so agents can install it repeatably with one script.
 
 ## Step 3.7: Install The OpenClaw Support KB
 
@@ -2028,7 +2056,15 @@ GBrain, sets up a Voyage 4 Large 2048d brain when `VOYAGE_API_KEY` is available,
 installs host plugins such as OpenClaw and Codex Desktop when those hosts are
 present, and verifies the local doctor score. ~30 minutes.
 
-For manual installs or upgrades from an existing checkout:
+For a full local OpenClaw/Codex/support-KB install from a shell:
+
+```bash
+git clone https://github.com/electricsheephq/eva-brain.git ~/eva-brain
+cd ~/eva-brain
+scripts/update-local-install.sh --with-openclaw --with-codex-plugin --with-support-kb --stop-stale-serve
+```
+
+For manual upgrades from an existing checkout:
 
 ```bash
 cd ~/eva-brain
@@ -2036,7 +2072,29 @@ scripts/update-local-install.sh
 ```
 
 Use `--with-openclaw` or `--with-codex-plugin` when you want the script to fail
-instead of auto-skipping a missing host.
+instead of auto-skipping a missing host. Use `--with-support-kb` to install or
+refresh the OpenClaw support knowledge base as a named GBrain source.
+
+### What Eva Adds
+
+Eva Brain tracks upstream GBrain closely. The downstream additions are the host
+and install surfaces our users need:
+
+- **OpenClaw native plugin:** `plugins/openclaw-gbrain` adds GBrain tools and
+  `/plugins/gbrain/extract`, using OpenClaw's logged-in Codex runtime for
+  extraction instead of asking users for an OpenAI API key.
+- **Codex Desktop plugin:** `plugins/gbrain-codex` is a thin local MCP package
+  that launches the installed `gbrain serve` for Codex Desktop.
+- **One-command updater:** `scripts/update-local-install.sh` safely updates the
+  checkout, links the CLI, runs idempotent local init/migrations, and optionally
+  refreshes host plugins and the support KB.
+- **Opinionated defaults:** Voyage 4 Large at 2048 dimensions for technical
+  workspaces, `~/.gbrain/gbrain.env` support, and safe local install behavior.
+
+Upstream GBrain still owns the database, search, sync, graph, facts, native
+media, provider recipes, and MCP core. Eva's media extraction schema is an
+adapter payload for host runtimes; it is not intended to replace upstream's
+native image/file/media storage model.
 
 For provider choice, embedding dimensions, Voyage 4 Large 2048d setup, and the OpenClaw Codex OAuth extraction boundary, read [`docs/guides/provider-install-matrix.md`](docs/guides/provider-install-matrix.md).
 

--- a/plugins/gbrain-codex/README.md
+++ b/plugins/gbrain-codex/README.md
@@ -47,6 +47,17 @@ The installer creates `~/plugins/gbrain-codex`, links this package plus the
 repo's current `skills/` tree, and updates
 `~/.agents/plugins/marketplace.json`.
 
+For the full public install path, including the CLI and optional host plugins:
+
+```bash
+git clone https://github.com/electricsheephq/eva-brain.git ~/eva-brain
+cd ~/eva-brain
+scripts/update-local-install.sh --with-codex-plugin
+```
+
+Add `--with-openclaw --with-support-kb` when this Codex install should share the
+same machine with OpenClaw and the OpenClaw support knowledge base.
+
 ## Local Repo Smoke
 
 From the Eva Brain repo root:

--- a/plugins/openclaw-gbrain/README.md
+++ b/plugins/openclaw-gbrain/README.md
@@ -19,13 +19,10 @@ From a fresh Eva Brain checkout:
 ```bash
 git clone https://github.com/electricsheephq/eva-brain.git ~/eva-brain
 cd ~/eva-brain
-curl -fsSL https://bun.sh/install | bash
-export PATH="$HOME/.bun/bin:$PATH"
-bun install && bun link
-gbrain --version
+scripts/update-local-install.sh --with-openclaw
 ```
 
-Then install the OpenClaw plugin from the same checkout:
+Or install the plugin manually from an existing checkout:
 
 ```bash
 openclaw plugins install --dangerously-force-unsafe-install ./plugins/openclaw-gbrain
@@ -44,6 +41,13 @@ or you can link it:
 
 ```bash
 openclaw plugins install --link --dangerously-force-unsafe-install ./plugins/openclaw-gbrain
+```
+
+For a full local support setup that also installs the Codex Desktop plugin and
+OpenClaw support KB:
+
+```bash
+scripts/update-local-install.sh --with-openclaw --with-codex-plugin --with-support-kb --stop-stale-serve
 ```
 
 ## Configure


### PR DESCRIPTION
## TL;DR

Clarifies the public Eva Brain install path so agents can install the CLI, OpenClaw plugin, Codex Desktop plugin, and OpenClaw support KB from one repo-owned flow instead of piecing commands together from several docs.

## What Changed

- Adds a full shell install command to `README.md` using `scripts/update-local-install.sh --with-openclaw --with-codex-plugin --with-support-kb --stop-stale-serve`.
- Adds a concise "What Eva Adds" section that separates upstream GBrain core from Eva's host/plugin/install surfaces.
- Expands `INSTALL_FOR_AGENTS.md` with what the full install command does and how OpenClaw/Codex plugin behavior differs from normal GBrain MCP use.
- Points the OpenClaw and Codex plugin package READMEs back to the repo-owned updater path.

## Why

The repo now supports a real one-link install story, but the instructions were scattered. This makes the expected path obvious for local agents and customer VMs: install from the Eva repo, keep `~/.gbrain` as runtime state, use Voyage for embeddings, use OpenClaw/Codex OAuth for extraction, and install the support KB as a named GBrain source when needed.

## Validation

- `git diff --check`

No runtime tests were run because this is docs-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded installation and upgrade guides with a one-command full local setup for OpenClaw, Codex Desktop, and support-KB workflows.
  * Added an explicit example command plus a “what that command does” checklist explaining steps performed.
  * Clarified how Eva’s plugins interact with upstream core services and what Eva adds (plugins, updater, opinionated defaults).
  * Improved guidance for agent deployments and repeatable local installs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/eva-brain/pull/87)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->