### PR TITLE
Fix OpenClaw extraction on VM gateway runtimes

### DIFF
--- a/plugins/openclaw-gbrain/index.js
+++ b/plugins/openclaw-gbrain/index.js
@@ -332,7 +332,7 @@ async function handleExtractionRoute(config, req, res) {
       "infer",
       "model",
       "run",
-      "--local",
+      "--gateway",
       "--model",
       resolveExtractionModel(request.model, config.extractionModel),
       "--prompt",

--- a/test/openclaw-gbrain-plugin-contract.test.ts
+++ b/test/openclaw-gbrain-plugin-contract.test.ts
@@ -14,8 +14,8 @@ describe('OpenClaw GBrain plugin boundary', () => {
     expect(pluginSource).toContain('GBRAIN_ROUTE_PATH = "/plugins/gbrain/extract"');
     expect(pluginSource).toContain('api.registerHttpRoute');
     expect(pluginSource).toContain('auth: "gateway"');
-    expect(pluginSource).toContain('"--local"');
-    expect(pluginSource).not.toContain('"--gateway"');
+    expect(pluginSource).toContain('"--gateway"');
+    expect(pluginSource).not.toContain('"--local"');
     expect(pluginSource).toContain('protocol: "gbrain.media-extraction.v1"');
     expect(pluginSource).toContain('provider: "openai-codex"');
   });


### PR DESCRIPTION
## TLDR

Switch the OpenClaw GBrain extraction plugin from `openclaw infer model run --local` to `--gateway`. Eric's customer-VM canary has a valid `openai-codex` OAuth profile, but the local execution path returns no text output; the gateway execution path succeeds on the same VM and is the right host-owned runtime surface for a gateway-loaded plugin.

Closes #91.

## Why

The plugin route `/plugins/gbrain/extract` lives inside OpenClaw's gateway. Its job is to use OpenClaw's already-authenticated Codex runtime and return normalized `gbrain.media-extraction.v1` without asking users for model API keys.

On Eric's VM:

```bash
openclaw infer model run --local --model openai-codex/gpt-5.5 --prompt "Say eric-smoke" --json
# Error: No text output returned for provider "openai-codex" model "gpt-5.5".

openclaw infer model run --gateway --model openai-codex/gpt-5.5 --prompt "Say eric-smoke" --json
# { "ok": true, "transport": "gateway", "outputs": [{ "text": "eric-smoke" }] }
```

So the plugin was installed correctly and auth existed, but it chose the wrong OpenClaw inference transport for VM-hosted Codex OAuth.

```mermaid
flowchart TD
  A[POST /plugins/gbrain/extract] --> B[OpenClaw GBrain plugin]
  B --> C[openclaw infer model run]
  C -->|before: --local| D[Codex OAuth path returns no text on VM]
  C -->|after: --gateway| E[Gateway model.run uses live host runtime]
  E --> F[gbrain.media-extraction.v1 response]
```

## What Changed

- `plugins/openclaw-gbrain/index.js`
  - Uses `--gateway` for the extraction model run.
- `test/openclaw-gbrain-plugin-contract.test.ts`
  - Asserts `--gateway` is used.
  - Rejects accidental regression back to `--local`.

## Validation

Local focused test:

```bash
bun test test/openclaw-gbrain-plugin-contract.test.ts
```

Result:

```text
5 pass
0 fail
```

Live canary evidence before this patch:

- Eric VM upgraded to `gbrain 0.33.0`.
- GBrain doctor with bundled skills dir: `100/100`.
- Voyage provider probe: green, `2048 dims`.
- Support KB: healthy, `649` pages.
- Gateway plugin: loaded, no diagnostics.
- `gbrain_status`: passes through gateway.
- `gbrain_search`: passes through gateway.
- `/plugins/gbrain/extract`: currently fails only because of the `--local` transport.

After this PR branch is installed on Eric, the acceptance smoke is:

```bash
POST /plugins/gbrain/extract
# ok: true
# protocol: gbrain.media-extraction.v1
# extraction.schemaVersion: gbrain.media-extraction.v1
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated extraction service runtime to use gateway mode for execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/eva-brain/pull/92)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->