### PR TITLE
test: guard OpenClaw plugin install metadata contracts

### DIFF
--- a/test/install-contract.test.ts
+++ b/test/install-contract.test.ts
@@ -18,6 +18,27 @@ describe('Eva Brain install contract', () => {
     expect(manifest.configSchema).not.toHaveProperty('voyage_api_key');
   });
 
+  test('root bundle plugin launches the installed gbrain serve runtime', () => {
+    const manifest = JSON.parse(readFileSync(join(root, 'openclaw.plugin.json'), 'utf8'));
+    const server = manifest.mcpServers?.gbrain;
+
+    expect(server?.command).toBe('gbrain');
+    expect(server?.args).toEqual(['serve']);
+  });
+
+  test('repo-owned version surfaces track the package version', () => {
+    const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+    const rootManifest = JSON.parse(readFileSync(join(root, 'openclaw.plugin.json'), 'utf8'));
+    const codexPkg = JSON.parse(readFileSync(join(root, 'plugins/gbrain-codex/package.json'), 'utf8'));
+    const codexPlugin = JSON.parse(readFileSync(join(root, 'plugins/gbrain-codex/.codex-plugin/plugin.json'), 'utf8'));
+    const versionSource = readFileSync(join(root, 'src/version.ts'), 'utf8');
+
+    expect(rootManifest.version).toBe(pkg.version);
+    expect(codexPkg.version).toBe(pkg.version);
+    expect(codexPlugin.version).toBe(pkg.version);
+    expect(versionSource).toContain('pkg.version');
+  });
+
   test('agent install guide preserves Eva, Voyage, OpenClaw, and support KB setup', () => {
     const guide = readFileSync(join(root, 'INSTALL_FOR_AGENTS.md'), 'utf8');
 


### PR DESCRIPTION
## TL;DR

Eva found two packaging-contract footguns that are mostly fixed on current `master`, but not yet protected well enough: the root OpenClaw bundle must launch the installed `gbrain serve` runtime, and repo-owned version surfaces must agree. This PR adds focused install-contract tests so the repo cannot drift back to a missing `./bin/gbrain` manifest or mismatched package/plugin versions.

Closes #93.
Closes #94.

## Why

Agents and installers need one boring answer to two questions:

1. What command does this repo-owned OpenClaw bundle actually run?
2. Which version is this checkout/package/plugin advertising?

If those answers drift, a fresh checkout can look installable while pointing at a missing binary, or a healthy install can look stale because package metadata, plugin metadata, and runtime output disagree.

```mermaid
flowchart LR
  A[Fresh eva-brain checkout] --> B[package.json version]
  A --> C[root openclaw.plugin.json]
  A --> D[Codex plugin metadata]
  C --> E[gbrain serve]
  B --> F[gbrain --version]
  D --> G[Codex Desktop install]
  B -.must match.-> C
  B -.must match.-> D
  C -.must launch.-> E
```

## What Changed

- Added an install-contract regression test that pins the root bundle MCP server to:
  - `command: "gbrain"`
  - `args: ["serve"]`
- Added an install-contract regression test that checks repo-owned version surfaces against `package.json`:
  - root `openclaw.plugin.json`
  - `plugins/gbrain-codex/package.json`
  - `plugins/gbrain-codex/.codex-plugin/plugin.json`
  - `src/version.ts` deriving runtime CLI version from package metadata

## Notes

The current `master` checkout already has the direct symptoms fixed: root `openclaw.plugin.json` is at `0.33.0` and uses `gbrain serve`, not `./bin/gbrain`. This PR makes that an explicit contract instead of relying on humans to notice future drift.

## Validation

```bash
git diff --check
bun test test/install-contract.test.ts
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation tests for configuration consistency across project files.
  * Added tests to verify version alignment across all configuration sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/eva-brain/pull/95)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->