### PR TITLE
fix: make seed-default local search read federated sources

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -536,12 +536,36 @@ async function makeContext(engine: BrainEngine, params: Record<string, unknown>)
   // 'default'. Wrapped in try/catch so a doctor / single-source brain that
   // never set up sources still returns 'default' silently.
   let sourceId: string | undefined;
+  let sourceIds: string[] | undefined;
   try {
-    const { resolveSourceId } = await import('./core/source-resolver.ts');
+    const { resolveSourceWithTier } = await import('./core/source-resolver.ts');
     // params.source is set when a CLI flag was parsed for the op (rare; most
     // CLI ops don't take --source). Falls through to env/dotfile/path-match.
     const explicit = (params.source as string | undefined) ?? null;
-    sourceId = await resolveSourceId(engine, explicit);
+    const resolved = await resolveSourceWithTier(engine, explicit);
+    sourceId = resolved.source_id;
+    if (resolved.tier === 'seed_default') {
+      const rows = await engine.executeRaw<{ id: string; config: unknown; archived?: boolean }>(
+        `SELECT id, config, archived FROM sources ORDER BY (id = 'default') DESC, id`,
+      );
+      sourceIds = rows
+        .filter((row) => row.archived !== true)
+        .filter((row) => {
+          let cfg: Record<string, unknown> = {};
+          if (typeof row.config === 'string') {
+            try {
+              cfg = JSON.parse(row.config || '{}') as Record<string, unknown>;
+            } catch {
+              cfg = {};
+            }
+          } else if (row.config && typeof row.config === 'object') {
+            cfg = row.config as Record<string, unknown>;
+          }
+          return cfg.federated === true;
+        })
+        .map((row) => row.id);
+      if (sourceIds.length === 0) sourceIds = undefined;
+    }
   } catch {
     // Source resolution failed (e.g. sources table doesn't exist on a fresh
     // pre-init brain). Leave sourceId unset; engine read methods fall through
@@ -557,6 +581,7 @@ async function makeContext(engine: BrainEngine, params: Record<string, unknown>)
     // confinement (e.g., cwd-locked file_upload).
     remote: false,
     cliOpts: getCliOptions(),
+    ...(sourceIds !== undefined ? { sourceIds } : {}),
     // v0.34 D4: sourceId is REQUIRED at the type level. Fall back to 'default'
     // when resolveSourceId returned undefined (fresh pre-init brain, no sources
     // table). Matches dispatch.ts's auto-fill so the contract holds across

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -283,6 +283,13 @@ export interface OperationContext {
    */
   auth?: AuthInfo;
   /**
+   * Local CLI-only read federation. When the source resolver falls all the way
+   * through to the seeded `default` source, read operations should search the
+   * federated source set instead of an often-empty default source. Remote
+   * callers use `auth.allowedSources`; writes still use scalar `sourceId`.
+   */
+  sourceIds?: string[];
+  /**
    * True when the caller is remote/untrusted (MCP over stdio/HTTP, or any agent-facing entry point).
    * False for local CLI invocations by the owner of the machine.
    *
@@ -418,6 +425,7 @@ export function sourceScopeOpts(ctx: OperationContext): { sourceId?: string; sou
   // value of `[]` MUST NOT widen scope to "all sources" by being interpreted
   // as "no filter."
   if (allowed && allowed.length > 0) return { sourceIds: allowed };
+  if (ctx.sourceIds && ctx.sourceIds.length > 0) return { sourceIds: ctx.sourceIds };
   if (ctx.sourceId) return { sourceId: ctx.sourceId };
   return {};
 }

--- a/test/cli-federated-default-search.serial.test.ts
+++ b/test/cli-federated-default-search.serial.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const repoRoot = new URL('..', import.meta.url).pathname;
+
+async function runCli(
+  args: string[],
+  env: Record<string, string>,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const childEnv: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) childEnv[key] = value;
+  }
+  delete childEnv.DATABASE_URL;
+  delete childEnv.GBRAIN_DATABASE_URL;
+  delete childEnv.GBRAIN_REMOTE_URL;
+  delete childEnv.GBRAIN_SOURCE;
+
+  const proc = Bun.spawn([process.execPath, 'run', 'src/cli.ts', ...args], {
+    cwd: repoRoot,
+    env: { ...childEnv, ...env },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, code };
+}
+
+describe('local CLI federated default search', () => {
+  test('seed-default local search reads federated sources instead of only the empty default source', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gbrain-federated-default-'));
+    const home = join(root, 'home');
+    const source = join(root, 'support-kb');
+    const env = { HOME: home, GBRAIN_HOME: home };
+
+    try {
+      mkdirSync(source, { recursive: true });
+      writeFileSync(
+        join(source, 'guide.md'),
+        `---\ntitle: Support Guide\ntype: note\n---\n\nfederatedneedle support knowledge lives here.\n`,
+      );
+
+      let result = await runCli(['init', '--pglite', '--no-embedding'], env);
+      expect(result.code).toBe(0);
+
+      result = await runCli([
+        'sources',
+        'add',
+        'support-kb',
+        '--path',
+        source,
+        '--name',
+        'Support KB',
+        '--federated',
+      ], env);
+      expect(result.code).toBe(0);
+
+      result = await runCli(['import', source, '--source', 'support-kb', '--no-embed'], env);
+      expect(result.code).toBe(0);
+
+      result = await runCli(['sources', 'current', '--json'], env);
+      expect(result.code).toBe(0);
+      expect(JSON.parse(result.stdout)).toMatchObject({
+        source_id: 'default',
+        tier: 'seed_default',
+      });
+
+      result = await runCli(['search', 'federatedneedle', '--limit', '3'], env);
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('guide');
+      expect(result.stdout).toContain('federatedneedle support knowledge');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
## TL;DR

Fixes a real local install failure from the v0.40.2 recovery: `gbrain search OpenClaw` returned `No results` even though Support KB had 947 pages, 6753 chunks, and 100% embedding coverage. The DB was fine; explicit `--source openclaw-support-kb` worked. Plain local CLI search was accidentally scoped to the empty seeded `default` source.

Closes #107.

## What changed

- `makeContext()` now uses `resolveSourceWithTier()` so it knows whether source resolution reached the seed fallback.
- When local CLI resolution is `seed_default`, it collects non-archived `config.federated === true` sources and stores them as a local read-source set.
- `sourceScopeOpts()` now uses that local read-source set after remote/OAuth `auth.allowedSources` and before scalar `sourceId`.
- Writes still use scalar `ctx.sourceId`; this is only a read-side federation path.

```mermaid
flowchart TD
  A[Local CLI cwd outside known source] --> B[resolveSourceWithTier]
  B --> C{tier}
  C -->|flag/env/dotfile/local_path/brain_default| D[scalar sourceId]
  C -->|seed_default| E[load federated source ids]
  E --> F[sourceScopeOpts returns sourceIds]
  D --> G[sourceScopeOpts returns sourceId]
  F --> H[read federated docs + KB]
  G --> I[read explicit source only]
```

## Why this is safe

Remote callers already have the stronger and narrower path: `auth.allowedSources` still wins. Explicit local source signals also stay scalar. The only changed case is the owner-local CLI with no source signal at all, where the existing user-facing source docs already promise federated sources appear in default cross-source search.

## Validation

Local focused checks run from `/Volumes/LEXAR/repos/eva-brain`:

```bash
bun test --max-concurrency=1 test/cli-federated-default-search.serial.test.ts
bun test --max-concurrency=1 test/e2e/source-isolation-pglite.test.ts test/commands-search.serial.test.ts
bun run typecheck
set -a; . /Users/lume/.gbrain/gbrain.env; set +a; bun run src/cli.ts search OpenClaw --limit 3
```

The real local Support KB smoke now returns KB rows without `--source`. GitHub Actions should run the full suite before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for federated search in the CLI, enabling queries across multiple federated sources simultaneously.

* **Tests**
  * Added integration test validating CLI federated search functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/eva-brain/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->