### PR TITLE
fix: warn on first cycle freshness

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1755,8 +1755,10 @@ export async function checkCycleFreshness(
         : `'${source.id}'`;
       const raw = source.config?.last_full_cycle_at;
       if (typeof raw !== 'string') {
-        issues.push(`Source ${display} has never completed a full cycle`);
-        hasFailures = true;
+        issues.push(
+          `Source ${display} has never completed a full cycle - run \`gbrain dream --source ${source.id}\` or start \`gbrain autopilot\` when you want enrichment`,
+        );
+        hasWarnings = true;
         continue;
       }
       const last = new Date(raw).getTime();

--- a/test/doctor-cycle-freshness.test.ts
+++ b/test/doctor-cycle-freshness.test.ts
@@ -79,12 +79,13 @@ describe('doctor checkCycleFreshness', () => {
     expect(result.message).toMatch(/gbrain dream --source/);
   });
 
-  test('source with NO last_full_cycle_at (never cycled) returns fail', async () => {
+  test('source with NO last_full_cycle_at (never cycled) returns warn', async () => {
     await engine.executeRaw(`UPDATE sources SET local_path = NULL WHERE id = 'default'`);
     await seed('virgin');
     const result = await checkCycleFreshness(engine, { nowMs: NOW });
-    expect(result.status).toBe('fail');
+    expect(result.status).toBe('warn');
     expect(result.message).toMatch(/never completed a full cycle/);
+    expect(result.message).toMatch(/gbrain dream --source virgin/);
   });
 
   test('mixed sources: highest severity wins (fail > warn > ok)', async () => {


### PR DESCRIPTION
## TL;DR

Freshly installed/searchable sources should not fail `gbrain doctor` just because optional dream/autopilot enrichment has not completed yet. This changes the first-cycle state from a hard failure to an actionable warning, while preserving the existing hard failure for truly stale cycle timestamps.

Closes #109.

## Why

The local Eva Brain install/update path was functionally healthy after the v0.40 catch-up and support-KB import:

- PGLite opened successfully
- schema was latest
- embeddings were 100% covered
- Voyage 4 Large returned 2048 dimensions
- Support KB search worked
- OpenClaw plugin loaded

But `doctor --json` returned unhealthy/exit 1 because `openclaw-support-kb` had no `last_full_cycle_at` yet. That is expected for a newly added source. Missing cycle metadata means "not enriched yet," not "database/search/install is broken."

## What Changed

- `checkCycleFreshness()` now reports sources with no `last_full_cycle_at` as `warn` with an explicit remediation command.
- Existing stale timestamp behavior is unchanged:
  - recent cycle: `ok`
  - moderately old cycle: `warn`
  - very stale cycle: `fail`
- Regression test updated so a never-cycled source proves the warning path.

## Local Validation

Ran from `/Volumes/LEXAR/repos/eva-brain`:

```bash
bun test --max-concurrency=1 test/doctor-cycle-freshness.test.ts
bun run typecheck
git diff --check
```

Results:

- doctor cycle freshness focused test: 9 pass / 0 fail
- typecheck: exit 0
- diff check: exit 0

## Confidence

95%+ because this is a two-line severity change with focused coverage, keeps stale-cycle failures intact, and matches the intended install semantics: retrieval/index health gates should not be blocked by optional enrichment that has never run on a fresh source.
