### PR TITLE
fix: make Codex plugin rehearsal provider independent

### DIFF
--- a/plugins/gbrain-codex/README.md
+++ b/plugins/gbrain-codex/README.md
@@ -68,9 +68,10 @@ test -x "$HOME/.bun/bin/gbrain" || bun link
 node plugins/gbrain-codex/scripts/rehearsal.mjs
 ```
 
-The rehearsal script creates a temp `GBRAIN_HOME`, initializes PGLite, connects
-to the plugin over stdio MCP, checks `tools/list`, and exercises `put_page`,
-`get_page`, `search`, `query`, `sync_brain`, and the `whoami` fail-closed path.
+The rehearsal script creates a temp `GBRAIN_HOME`, initializes PGLite with
+deferred embeddings so no provider API key is required, connects to the plugin
+over stdio MCP, checks `tools/list`, and exercises `put_page`, `get_page`,
+`search`, `query`, `sync_brain`, and the `whoami` fail-closed path.
 
 ## Safety Boundary
 

--- a/plugins/gbrain-codex/scripts/rehearsal.mjs
+++ b/plugins/gbrain-codex/scripts/rehearsal.mjs
@@ -32,8 +32,12 @@ function runAndCapture(command, args, env) {
   return result.stdout.trim();
 }
 
+export function rehearsalInitArgs() {
+  return ['init', '--pglite', '--non-interactive', '--json', '--no-embedding'];
+}
+
 function ensureTempBrain(command, env) {
-  runAndCapture(command, ['init', '--pglite', '--non-interactive', '--json'], env);
+  runAndCapture(command, rehearsalInitArgs(), env);
 }
 
 function expectedToolNames(command, env) {

--- a/test/local-updater-contract.test.ts
+++ b/test/local-updater-contract.test.ts
@@ -73,6 +73,12 @@ describe('public local updater and Codex plugin packaging', () => {
     expect(mcp.mcpServers['gbrain-codex'].args).toContain('./scripts/launch-gbrain-serve.mjs');
   });
 
+  test('Codex plugin rehearsal is provider-key independent', () => {
+    const rehearsal = readFileSync(join(root, 'plugins/gbrain-codex/scripts/rehearsal.mjs'), 'utf8');
+    expect(rehearsal).toContain("'--no-embedding'");
+    expect(rehearsal).toMatch(/function ensureTempBrain[\s\S]*rehearsalInitArgs\(\)/);
+  });
+
   test('Codex installer creates a local plugin shell linked to current repo skills', () => {
     const home = tempHome();
     const result = Bun.spawnSync({


### PR DESCRIPTION
## TL;DR

Fixes the Codex Desktop plugin smoke so it proves the plugin works without requiring any embedding provider API key. The rehearsal now initializes its temporary brain with `--no-embedding`, so unrelated shell credentials like a stale `DASHSCOPE_API_KEY` cannot make the smoke fail before it reaches the plugin checks.

Closes #111.

## Why

During the local post-merge install smoke, the normal Eva Brain install was healthy:

- `gbrain providers test --model voyage:voyage-4-large` returned 2048 dims
- Support KB search worked
- OpenClaw plugin loaded
- doctor returned warnings/90 instead of unhealthy

But the Codex plugin rehearsal failed because it created a fresh temp `GBRAIN_HOME` and inherited an unrelated `DASHSCOPE_API_KEY` from the shell. `gbrain init` configured that temp brain for DashScope, then `put_page` tried to embed through an invalid key.

That is the wrong contract for a plugin rehearsal. The rehearsal should validate the Codex adapter/stdio MCP path, not whichever provider credentials happen to exist in the developer shell.

## What Changed

- Added `rehearsalInitArgs()` and made the rehearsal initialize with:

```bash
gbrain init --pglite --non-interactive --json --no-embedding
```

- Updated the Codex plugin README to say the rehearsal uses deferred embeddings and does not require a provider API key.
- Added a packaging contract test pinning the provider-key-independent rehearsal behavior.

## Validation

Ran from `/Volumes/LEXAR/repos/eva-brain`:

```bash
node plugins/gbrain-codex/scripts/rehearsal.mjs
bun test --max-concurrency=1 test/local-updater-contract.test.ts
bun run typecheck
git diff --check
```

Results:

- Codex rehearsal: `ok: true`, 74 tools, exercises `put_page`, `get_page`, `search`, `query`, `sync_brain`, and `whoami`
- local updater/plugin contract tests: 9 pass / 0 fail
- typecheck: exit 0
- diff check: exit 0

## Confidence

95%+ because the failure was reproduced with the stale DashScope env still present, the fix removes provider setup from the temporary rehearsal brain, and the actual rehearsal now passes end to end under the previously failing environment.
