### PR TITLE
fix: make Codex plugin symlink entrypoints executable

### DIFF
--- a/plugins/gbrain-codex/scripts/launch-gbrain-serve.mjs
+++ b/plugins/gbrain-codex/scripts/launch-gbrain-serve.mjs
@@ -1,11 +1,19 @@
 import { spawn } from 'node:child_process';
-import { accessSync, constants, existsSync } from 'node:fs';
+import { accessSync, constants, existsSync, realpathSync } from 'node:fs';
 import { userInfo } from 'node:os';
 import { delimiter, dirname, isAbsolute, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
 const PLUGIN_ROOT = resolve(dirname(SCRIPT_PATH), '..');
+
+function sameEntrypointPath(left, right) {
+  try {
+    return realpathSync(left) === realpathSync(right);
+  } catch {
+    return resolve(left) === resolve(right);
+  }
+}
 
 function isExecutable(path) {
   try {
@@ -140,7 +148,7 @@ export async function main(argv = process.argv.slice(2), env = process.env) {
   });
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === SCRIPT_PATH) {
+if (process.argv[1] && sameEntrypointPath(process.argv[1], SCRIPT_PATH)) {
   main().catch(err => {
     process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
     process.exit(1);

--- a/plugins/gbrain-codex/scripts/rehearsal.mjs
+++ b/plugins/gbrain-codex/scripts/rehearsal.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -12,6 +12,14 @@ import { resolveGbrainExecutable } from './launch-gbrain-serve.mjs';
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
 const PLUGIN_ROOT = resolve(dirname(SCRIPT_PATH), '..');
 const REPO_ROOT = resolve(PLUGIN_ROOT, '..', '..');
+
+function sameEntrypointPath(left, right) {
+  try {
+    return realpathSync(left) === realpathSync(right);
+  } catch {
+    return resolve(left) === resolve(right);
+  }
+}
 
 function textContent(result) {
   const first = Array.isArray(result?.content) ? result.content[0] : null;
@@ -178,7 +186,7 @@ export async function runRehearsal({ env = process.env } = {}) {
   }
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === SCRIPT_PATH) {
+if (process.argv[1] && sameEntrypointPath(process.argv[1], SCRIPT_PATH)) {
   runRehearsal().then(result => {
     process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
   }).catch(err => {

--- a/test/local-updater-contract.test.ts
+++ b/test/local-updater-contract.test.ts
@@ -102,6 +102,19 @@ describe('public local updater and Codex plugin packaging', () => {
     expect(entry.source.path).toBe('./plugins/gbrain-codex');
     expect(entry.policy.installation).toBe('AVAILABLE');
     expect(entry.policy.authentication).toBe('ON_INSTALL');
+
+    const rehearsal = Bun.spawnSync({
+      cmd: ['node', join(pluginDir, 'scripts/rehearsal.mjs')],
+      cwd: root,
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: {
+        ...process.env,
+        DASHSCOPE_API_KEY: 'invalid-key-for-provider-independent-rehearsal',
+      },
+    });
+    expect(rehearsal.exitCode).toBe(0);
+    expect(JSON.parse(rehearsal.stdout.toString()).ok).toBe(true);
   });
 
   test('Codex installer replaces stale or broken local gbrain-codex symlinks', () => {


### PR DESCRIPTION
## TL;DR

Fixes the installed Codex plugin shell so symlinked scripts actually run. The installer intentionally symlinks `~/plugins/gbrain-codex/scripts` back to the repo; the entrypoint guards now compare real paths so both repo paths and installed symlink paths execute correctly.

Closes #113.

## Why

After #112, the repo-path rehearsal worked, but the installed path smoke exposed another issue:

```bash
node /Users/lume/plugins/gbrain-codex/scripts/rehearsal.mjs
```

It exited `0` with no output. The script did not fail; it simply never entered its main block because:

- `import.meta.url` resolved to the real repo file
- `process.argv[1]` was the installed symlink path
- the guard compared `resolve(argv[1]) === SCRIPT_PATH`

The same guard pattern existed in `launch-gbrain-serve.mjs`, the MCP launcher Codex actually uses. So this needed to be fixed before calling the installed Codex plugin package healthy.

## What Changed

- Added symlink-safe `sameEntrypointPath()` to both Codex scripts.
- Uses `realpathSync(left) === realpathSync(right)` with a `resolve()` fallback.
- Added a regression to install the Codex plugin into a temp home and run the symlinked `scripts/rehearsal.mjs` path with an invalid DashScope key.

## Validation

Ran from `/Volumes/LEXAR/repos/eva-brain`:

```bash
node /Users/lume/plugins/gbrain-codex/scripts/rehearsal.mjs
bun test --max-concurrency=1 test/local-updater-contract.test.ts
bun run typecheck
git diff --check
```

Results:

- installed-path Codex rehearsal: `ok: true`, 74 tools
- local updater/plugin contract tests: 9 pass / 0 fail
- typecheck: exit 0
- diff check: exit 0

## Confidence

95%+ because the exact installed-path no-op was reproduced before the fix, the installed-path rehearsal now runs and returns JSON, and the regression test exercises a temp installed symlink path rather than only checking repo files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved symlink path resolution in plugin installation and execution scripts to handle edge cases where filesystem paths differ due to symbolic links.

* **Tests**
  * Enhanced plugin installation validation to verify rehearsal process behavior with various configuration states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/eva-brain/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->