### PR TITLE
ci: allow manual Test workflow dispatch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## TL;DR

Adds `workflow_dispatch` to the `Test` workflow so Eva Brain can run full unit/gitleaks validation in GitHub on demand instead of falling back to broad local CI runs.

Closes #115.

## Why

Our validation policy is GitHub for full-suite checks, local only for narrow installed-product smoke. `E2E Tests` already supports manual dispatch, but `Test` does not. When a PR/push event fails to create a current Test run, or a transient setup failure needs a clean rerun, agents currently have no GitHub-native way to validate the current commit.

## What Changed

- Added `workflow_dispatch` to `.github/workflows/test.yml`.
- No job, permission, matrix, test command, or trigger behavior was changed for normal `push` / `pull_request` runs.

## Validation

Local validation was intentionally limited to lightweight static checks, not CI duplication:

- `git diff --check`
- Manual diff inspection of `.github/workflows/test.yml`

Full validation will be GitHub-hosted through this PR and then a manual `Test` dispatch on `master` after merge.
