### PR TITLE
fix: keep PGLite search from hanging after results

### DIFF
--- a/src/core/last-retrieved.ts
+++ b/src/core/last-retrieved.ts
@@ -87,6 +87,12 @@ export async function awaitPendingLastRetrievedWrites(): Promise<void> {
  */
 export function bumpLastRetrievedAt(engine: BrainEngine, pageIds: number[]): void {
   if (pageIds.length === 0) return;
+  if (engine.kind === 'pglite') {
+    // PGLite is a single-process local store. This signal is best-effort
+    // telemetry for stale-page ranking, so never let it compete with the
+    // user-facing CLI process for the embedded DB lifecycle.
+    return;
+  }
   // Fire-and-forget on purpose. We deliberately do NOT return the promise.
   const write = (async () => {
     try {

--- a/test/last-retrieved.test.ts
+++ b/test/last-retrieved.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+import type { BrainEngine } from '../src/core/engine.ts';
+import { awaitPendingLastRetrievedWrites, bumpLastRetrievedAt } from '../src/core/last-retrieved.ts';
+
+describe('last retrieved write-back', () => {
+  test('skips optional write-back on PGLite so local search can exit cleanly', async () => {
+    let executeCalled = false;
+    const engine = {
+      kind: 'pglite',
+      async executeRaw() {
+        executeCalled = true;
+        throw new Error('PGLite write-back should not run');
+      },
+      async getConfig() {
+        return 'true';
+      },
+    } as unknown as BrainEngine;
+
+    bumpLastRetrievedAt(engine, [1, 2, 3]);
+    await awaitPendingLastRetrievedWrites();
+
+    expect(executeCalled).toBe(false);
+  });
+});


### PR DESCRIPTION
## TL;DR

Fixes a local PGLite smoke failure where `gbrain search` could print results and then stay alive because the optional `pages.last_retrieved_at` write-back was still running. PGLite is single-process, so this best-effort telemetry should never compete with the user-facing CLI lifecycle.

Closes #117.

## What changed

- Skip `last_retrieved_at` write-back when the active engine is PGLite.
- Keep the Postgres write-back path unchanged.
- Add a regression test proving PGLite does not attempt the optional write-back.

## Why this is the right tradeoff

`last_retrieved_at` is telemetry for LSD/brainstorm stale-page ranking. Search correctness and fleet smoke reliability matter more than that optional signal on local embedded brains. Postgres remains the right engine for multi-process/background telemetry; PGLite remains reliable for local single-process search.

## Local focused validation

No local CI/full-suite run.

- `bun test test/last-retrieved.test.ts`
- `git diff --check`
- `gbrain config set search.track_retrieval true`
- `gbrain search OpenClaw --limit 3` exits cleanly
- `gbrain doctor --json` returns health score 90 with only known resolver/cycle freshness warnings
- `gbrain sources list --json` shows `openclaw-support-kb` with 947 pages
- `node /Users/lume/plugins/gbrain-codex/scripts/rehearsal.mjs` returns `ok: true`
- `openclaw plugins inspect gbrain --runtime --json` reports status `loaded`, 3 tools, 1 HTTP route

## GitHub validation

Let GitHub Actions run the full `Test`, `E2E Tests`, CodeQL, Socket, and review-bot gates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced local search database performance by eliminating unnecessary background database write operations that could compete for system resources
  * Ensured all existing data tracking, write throttling, and error handling mechanisms remain fully functional for non-local database setups

* **Tests**
  * Added test suite to verify that database write operations are correctly optimized and skipped in local search scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/eva-brain/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->