### PR TITLE
Fix doctor score drift from Support KB routing and Codex serve cleanup

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2498,7 +2498,7 @@ This is the dispatcher. Skills are the implementation. **Read the skill file bef
 | "Skillify this", "is this a skill?", "make this proper" | `skills/skillify/SKILL.md` |
 | "Compress my resolver", "AGENTS.md too large", "RESOLVER.md too big", "functional area dispatcher", "shrink routing table" | `skills/functional-area-resolver/SKILL.md` |
 | "Is gbrain healthy?", morning health check, skillpack-check | `skills/skillpack-check/SKILL.md` |
-| "harvest this skill into gbrain", "publish this skill to gbrain", "lift this skill upstream", "share this skill with other gbrain clients", "promote my skill to gbrain" | `skills/skillpack-harvest/SKILL.md` |
+| "harvest this skill into gbrain", "harvest my skill into gbrain", "publish this skill to gbrain", "publish my fork", "lift this skill upstream", "lift this skill", "share this skill", "share this skill with other gbrain clients", "promote my skill to gbrain", "promote this skill to gbrain", "skill in the gbrain bundle", "custom skill into the gbrain core" | `skills/skillpack-harvest/SKILL.md` |
 | Post-restart health + auto-fix, "did the container restart break anything", smoke test | `skills/smoke-test/SKILL.md` |
 | Cross-modal review, second opinion | `skills/cross-modal-review/SKILL.md` |
 | "Validate skills", skill health check | `skills/testing/SKILL.md` |

--- a/plugins/gbrain-codex/scripts/launch-gbrain-serve.mjs
+++ b/plugins/gbrain-codex/scripts/launch-gbrain-serve.mjs
@@ -64,6 +64,80 @@ export function buildServeArgs(extraArgs = []) {
   return ['serve', ...extraArgs];
 }
 
+export function bindChildLifecycle(
+  child,
+  {
+    parentProcess = process,
+    stdin = process.stdin,
+    forceKillAfterMs = 2000,
+  } = {},
+) {
+  let forceTimer = null;
+  let cleaned = false;
+  const signals = ['SIGINT', 'SIGTERM', 'SIGHUP'];
+
+  const childStillRunning = () =>
+    child.exitCode === null && child.signalCode === null;
+
+  const clearForceTimer = () => {
+    if (forceTimer) {
+      clearTimeout(forceTimer);
+      forceTimer = null;
+    }
+  };
+
+  const terminateChild = (signal = 'SIGTERM') => {
+    if (!childStillRunning()) return;
+    try {
+      child.kill(signal);
+    } catch {
+      return;
+    }
+    clearForceTimer();
+    forceTimer = setTimeout(() => {
+      if (childStillRunning()) {
+        try {
+          child.kill('SIGKILL');
+        } catch {
+          // Best effort. The parent will exit when the child does.
+        }
+      }
+    }, forceKillAfterMs);
+    if (typeof forceTimer.unref === 'function') forceTimer.unref();
+  };
+
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
+    clearForceTimer();
+    for (const signal of signals) {
+      parentProcess.off?.(signal, signalHandlers.get(signal));
+      parentProcess.removeListener?.(signal, signalHandlers.get(signal));
+    }
+    parentProcess.off?.('exit', onParentExit);
+    parentProcess.removeListener?.('exit', onParentExit);
+    stdin?.off?.('close', onInputClosed);
+    stdin?.removeListener?.('close', onInputClosed);
+    stdin?.off?.('end', onInputClosed);
+    stdin?.removeListener?.('end', onInputClosed);
+  };
+
+  const onInputClosed = () => terminateChild('SIGTERM');
+  const onParentExit = () => terminateChild('SIGTERM');
+  const signalHandlers = new Map(
+    signals.map(signal => [signal, () => terminateChild(signal)]),
+  );
+
+  for (const [signal, handler] of signalHandlers) parentProcess.once?.(signal, handler);
+  parentProcess.once?.('exit', onParentExit);
+  stdin?.once?.('close', onInputClosed);
+  stdin?.once?.('end', onInputClosed);
+  child.once?.('exit', cleanup);
+  child.once?.('close', cleanup);
+
+  return cleanup;
+}
+
 function gbrainConfigPath(home) {
   return home ? join(home, '.gbrain', 'config.json') : '';
 }
@@ -136,6 +210,7 @@ export async function main(argv = process.argv.slice(2), env = process.env) {
     },
     stdio: 'inherit',
   });
+  bindChildLifecycle(child);
 
   child.on('error', err => {
     process.stderr.write(`[gbrain-codex] failed to launch gbrain: ${err.message}\n`);

--- a/scripts/update-local-install.sh
+++ b/scripts/update-local-install.sh
@@ -233,6 +233,7 @@ install_support_kb() {
   run node "$kb_dir/scripts/status.mjs"
   run "$HOME/.bun/bin/gbrain" sync --repo "$kb_dir" --source openclaw-support-kb --no-embed
   run "$HOME/.bun/bin/gbrain" embed --stale --source openclaw-support-kb
+  run "$HOME/.bun/bin/gbrain" sources cycle-freshness openclaw-support-kb off
 }
 
 main() {

--- a/skills/RESOLVER.md
+++ b/skills/RESOLVER.md
@@ -62,7 +62,7 @@ This is the dispatcher. Skills are the implementation. **Read the skill file bef
 | "Skillify this", "is this a skill?", "make this proper" | `skills/skillify/SKILL.md` |
 | "Compress my resolver", "AGENTS.md too large", "RESOLVER.md too big", "functional area dispatcher", "shrink routing table" | `skills/functional-area-resolver/SKILL.md` |
 | "Is gbrain healthy?", morning health check, skillpack-check | `skills/skillpack-check/SKILL.md` |
-| "harvest this skill into gbrain", "publish this skill to gbrain", "lift this skill upstream", "share this skill with other gbrain clients", "promote my skill to gbrain" | `skills/skillpack-harvest/SKILL.md` |
+| "harvest this skill into gbrain", "harvest my skill into gbrain", "publish this skill to gbrain", "publish my fork", "lift this skill upstream", "lift this skill", "share this skill", "share this skill with other gbrain clients", "promote my skill to gbrain", "promote this skill to gbrain", "skill in the gbrain bundle", "custom skill into the gbrain core" | `skills/skillpack-harvest/SKILL.md` |
 | Post-restart health + auto-fix, "did the container restart break anything", smoke test | `skills/smoke-test/SKILL.md` |
 | Cross-modal review, second opinion | `skills/cross-modal-review/SKILL.md` |
 | "Validate skills", skill health check | `skills/testing/SKILL.md` |

--- a/skills/skillpack-harvest/SKILL.md
+++ b/skills/skillpack-harvest/SKILL.md
@@ -9,10 +9,17 @@ description: |
   lift fork-specific conventions to references).
 triggers:
   - "harvest this skill into gbrain"
+  - "harvest my skill into gbrain"
   - "publish this skill to gbrain"
+  - "publish my fork"
   - "lift this skill upstream"
+  - "lift this skill"
+  - "share this skill"
   - "share this skill with other gbrain clients"
   - "promote my skill to gbrain"
+  - "promote this skill to gbrain"
+  - "skill in the gbrain bundle"
+  - "custom skill into the gbrain core"
 mutating: true
 writes_pages: false
 writes_to:

--- a/src/commands/autopilot-fanout.ts
+++ b/src/commands/autopilot-fanout.ts
@@ -130,6 +130,10 @@ export function selectSourcesForDispatch(
   const stale: SourceRow[] = [];
   const fresh: SourceRow[] = [];
   for (const s of sources) {
+    if (s.config?.cycle_freshness === false) {
+      fresh.push(s);
+      continue;
+    }
     (isSourceStale(s, now, floorMin) ? stale : fresh).push(s);
   }
   // Oldest-first ordering: NULL last_full_cycle_at sorts before any timestamp.

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1748,11 +1748,16 @@ export async function checkCycleFreshness(
     const issues: string[] = [];
     let hasWarnings = false;
     let hasFailures = false;
+    let skippedCycleOptional = 0;
 
     for (const source of sources) {
       const display = source.name && source.name !== source.id
         ? `'${source.id}' (${source.name})`
         : `'${source.id}'`;
+      if (source.config?.cycle_freshness === false) {
+        skippedCycleOptional++;
+        continue;
+      }
       const raw = source.config?.last_full_cycle_at;
       if (typeof raw !== 'string') {
         issues.push(
@@ -1800,7 +1805,9 @@ export async function checkCycleFreshness(
     return {
       name: 'cycle_freshness',
       status: 'ok',
-      message: `All ${sources.length} federated source(s) cycled recently`,
+      message: skippedCycleOptional > 0
+        ? `All cycle-required source(s) cycled recently (${skippedCycleOptional} retrieval-only source(s) skipped)`
+        : `All ${sources.length} federated source(s) cycled recently`,
     };
   } catch (e) {
     return {

--- a/src/commands/dream.ts
+++ b/src/commands/dream.ts
@@ -30,6 +30,7 @@ import {
   type CyclePhase,
   type CycleReport,
 } from '../core/cycle.ts';
+import { assertValidSourceId } from '../core/source-id.ts';
 import { existsSync } from 'fs';
 
 interface DreamArgs {
@@ -53,6 +54,8 @@ interface DreamArgs {
    * Never auto-applied for --input (codex finding #3).
    */
   bypassDreamGuard: boolean;
+  /** Run against a registered source's local_path and freshness row. */
+  sourceId: string | null;
 }
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
@@ -70,6 +73,25 @@ function parseArgs(args: string[]): DreamArgs {
 
   const dirIdx = args.indexOf('--dir');
   const dir = dirIdx !== -1 ? args[dirIdx + 1] : null;
+
+  const sourceIdx = args.indexOf('--source');
+  const sourceId = sourceIdx !== -1 ? args[sourceIdx + 1] ?? null : null;
+  if (sourceIdx !== -1 && !sourceId) {
+    console.error('--source requires a source id');
+    process.exit(2);
+  }
+  if (sourceId) {
+    try {
+      assertValidSourceId(sourceId);
+    } catch (e) {
+      console.error(e instanceof Error ? e.message : String(e));
+      process.exit(2);
+    }
+  }
+  if (dir && sourceId) {
+    console.error('--dir cannot be combined with --source; registered sources already define their local_path.');
+    process.exit(2);
+  }
 
   const inputIdx = args.indexOf('--input');
   const inputFile = inputIdx !== -1 ? args[inputIdx + 1] ?? null : null;
@@ -121,6 +143,7 @@ function parseArgs(args: string[]): DreamArgs {
     from,
     to,
     bypassDreamGuard: args.includes('--unsafe-bypass-dream-guard'),
+    sourceId,
   };
 }
 
@@ -138,6 +161,7 @@ function parseArgs(args: string[]): DreamArgs {
 async function resolveBrainDir(
   engine: BrainEngine | null,
   explicit: string | null,
+  sourceId: string | null = null,
 ): Promise<string> {
   if (explicit) {
     if (!existsSync(explicit)) {
@@ -145,6 +169,28 @@ async function resolveBrainDir(
       process.exit(1);
     }
     return explicit;
+  }
+
+  if (sourceId) {
+    if (!engine) {
+      console.error(`--source ${sourceId} requires a configured database so gbrain can resolve the source path.`);
+      process.exit(1);
+    }
+    const sources = await engine.listAllSources();
+    const source = sources.find(s => s.id === sourceId);
+    if (!source) {
+      console.error(`Source "${sourceId}" not found. Run: gbrain sources list`);
+      process.exit(4);
+    }
+    if (!source.local_path) {
+      console.error(`Source "${sourceId}" has no local_path. Run: gbrain sources add ${sourceId} --path <path>`);
+      process.exit(4);
+    }
+    if (!existsSync(source.local_path)) {
+      console.error(`Source "${sourceId}" path does not exist: ${source.local_path}`);
+      process.exit(1);
+    }
+    return source.local_path;
   }
 
   if (engine) {
@@ -179,6 +225,8 @@ Options:
   --phase <name>      Run a single phase: ${ALL_PHASES.join(' | ')}
   --pull              git pull the brain repo before syncing (default: no pull)
   --dir <path>        Brain directory (default: configured brain)
+  --source <id>       Registered source id. Uses that source's local_path and
+                      updates its last_full_cycle_at on successful cycles.
 
   --input <file>      Synthesize a specific transcript file (implies
                       --phase synthesize). Bypasses corpus-dir scan.
@@ -272,7 +320,7 @@ export async function runDream(engine: BrainEngine | null, args: string[]): Prom
     return;
   }
 
-  const brainDir = await resolveBrainDir(engine, opts.dir);
+  const brainDir = await resolveBrainDir(engine, opts.dir, opts.sourceId);
   const phases: CyclePhase[] | undefined = opts.phase ? [opts.phase] : undefined;
 
   const report = await runCycle(engine, {
@@ -285,6 +333,7 @@ export async function runDream(engine: BrainEngine | null, args: string[]): Prom
     synthFrom: opts.from ?? undefined,
     synthTo: opts.to ?? undefined,
     synthBypassDreamGuard: opts.bypassDreamGuard,
+    sourceId: opts.sourceId ?? undefined,
   });
 
   if (opts.json) {

--- a/src/commands/sources.ts
+++ b/src/commands/sources.ts
@@ -491,6 +491,32 @@ async function runFederate(engine: BrainEngine, args: string[], value: boolean):
   console.log(`Source "${id}" is now ${value ? 'federated (appears in cross-source default search)' : 'isolated (only searched when explicitly named)'}.`);
 }
 
+async function runCycleFreshness(engine: BrainEngine, args: string[]): Promise<void> {
+  const id = args[0];
+  const mode = args[1];
+  if (!id || (mode !== 'on' && mode !== 'off')) {
+    console.error('Usage: gbrain sources cycle-freshness <id> <on|off>');
+    process.exit(2);
+  }
+  validateSourceId(id);
+  const src = await fetchSource(engine, id);
+  if (!src) {
+    console.error(`Source "${id}" not found.`);
+    process.exit(4);
+  }
+  const config = parseConfig(src.config);
+  if (mode === 'off') {
+    config.cycle_freshness = false;
+  } else {
+    delete config.cycle_freshness;
+  }
+  await engine.executeRaw(
+    `UPDATE sources SET config = $1::jsonb WHERE id = $2`,
+    [JSON.stringify(config), id],
+  );
+  console.log(`Source "${id}" cycle freshness is now ${mode === 'off' ? 'disabled (retrieval-only)' : 'enabled'}.`);
+}
+
 // ── `sources current` (v0.37.7.0) ──────────────────────────
 //
 // Verify which source the CLI would target before running a
@@ -552,6 +578,7 @@ export async function runSources(engine: BrainEngine, args: string[]): Promise<v
     case 'detach':     runDetach(); return;
     case 'federate':   return runFederate(engine, rest, true);
     case 'unfederate': return runFederate(engine, rest, false);
+    case 'cycle-freshness': return runCycleFreshness(engine, rest);
     case 'archive':    return runArchive(engine, rest);
     case 'restore':    return runRestore(engine, rest);
     case 'purge':      return runPurge(engine, rest);
@@ -598,6 +625,8 @@ Subcommands:
                                     targeting the brain you think you are.
   federate <id>                     Make source appear in cross-source default search.
   unfederate <id>                   Isolate source from default search.
+  cycle-freshness <id> <on|off>     Toggle doctor/autopilot full-cycle freshness
+                                    for retrieval-only sources.
 
 Source id: [a-z0-9-]{1,32}. Immutable citation key.
 

--- a/test/autopilot-fanout.test.ts
+++ b/test/autopilot-fanout.test.ts
@@ -90,6 +90,16 @@ describe('selectSourcesForDispatch', () => {
     expect(result.skippedCap).toEqual([]);
   });
 
+  test('cycle_freshness=false sources are not dispatched', () => {
+    const result = selectSourcesForDispatch(
+      [src('support-kb', null, { cycle_freshness: false }), src('normal')],
+      10,
+      NOW,
+    );
+    expect(result.dispatch.map(s => s.id)).toEqual(['normal']);
+    expect(result.skippedFresh.map(s => s.id)).toEqual(['support-kb']);
+  });
+
   test('never-cycled (NULL) sorts before timestamped', () => {
     const result = selectSourcesForDispatch(
       [fresh('b', 90), src('a'), fresh('c', 120)],

--- a/test/check-resolvable.test.ts
+++ b/test/check-resolvable.test.ts
@@ -97,6 +97,13 @@ describe("checkResolvable — real skills directory", () => {
     expect(orphans.length).toBe(0);
   });
 
+  test("skillpack-harvest routing fixtures are covered by deterministic triggers", () => {
+    const harvestRoutingIssues = report.issues.filter(
+      i => i.skill === "skillpack-harvest" && i.type.startsWith("routing_"),
+    );
+    expect(harvestRoutingIssues).toEqual([]);
+  });
+
   test("action strings are specific (contain file paths)", () => {
     for (const issue of report.issues) {
       expect(issue.action.length).toBeGreaterThan(10);
@@ -288,4 +295,3 @@ function afterEachCleanup(fn: () => void) {
   const { afterEach } = require("bun:test");
   afterEach(fn);
 }
-

--- a/test/doctor-cycle-freshness.test.ts
+++ b/test/doctor-cycle-freshness.test.ts
@@ -29,16 +29,21 @@ beforeEach(async () => {
 const NOW = Date.parse('2026-05-22T12:00:00.000Z');
 const agoH = (h: number) => new Date(NOW - h * 3600_000).toISOString();
 
-async function seed(id: string, lastFullCycleAt?: string, opts: { local_path?: string | null } = {}): Promise<void> {
-  const config = lastFullCycleAt
-    ? JSON.stringify({ last_full_cycle_at: lastFullCycleAt })
-    : '{}';
+async function seed(
+  id: string,
+  lastFullCycleAt?: string,
+  opts: { local_path?: string | null; config?: Record<string, unknown> } = {},
+): Promise<void> {
+  const config = {
+    ...(opts.config ?? {}),
+    ...(lastFullCycleAt ? { last_full_cycle_at: lastFullCycleAt } : {}),
+  };
   const localPath = opts.local_path === undefined ? `/tmp/${id}` : opts.local_path;
   await engine.executeRaw(
     `INSERT INTO sources (id, name, local_path, config, archived, created_at)
      VALUES ($1, $2, $3, $4::jsonb, false, NOW())
      ON CONFLICT (id) DO UPDATE SET local_path = EXCLUDED.local_path, config = EXCLUDED.config`,
-    [id, id, localPath, config],
+    [id, id, localPath, JSON.stringify(config)],
   );
 }
 
@@ -86,6 +91,14 @@ describe('doctor checkCycleFreshness', () => {
     expect(result.status).toBe('warn');
     expect(result.message).toMatch(/never completed a full cycle/);
     expect(result.message).toMatch(/gbrain dream --source virgin/);
+  });
+
+  test('retrieval-only sources can opt out of full-cycle freshness', async () => {
+    await engine.executeRaw(`UPDATE sources SET local_path = NULL WHERE id = 'default'`);
+    await seed('support-kb', undefined, { config: { cycle_freshness: false } });
+    const result = await checkCycleFreshness(engine, { nowMs: NOW });
+    expect(result.status).toBe('ok');
+    expect(result.message).toMatch(/retrieval-only source/);
   });
 
   test('mixed sources: highest severity wins (fail > warn > ok)', async () => {

--- a/test/dream.test.ts
+++ b/test/dream.test.ts
@@ -76,6 +76,31 @@ describe('runDream — brainDir resolution', () => {
     if (report) expect(report.brain_dir).toBe(repo);
   });
 
+  test('--source resolves the registered source local_path and updates cycle freshness', async () => {
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path, config, archived, created_at)
+       VALUES ('kb', 'KB', $1, '{}'::jsonb, false, NOW())
+       ON CONFLICT (id) DO UPDATE SET local_path = EXCLUDED.local_path, config = EXCLUDED.config`,
+      [repo],
+    );
+    const report = await runDream(engine, ['--source', 'kb', '--phase', 'lint', '--json']);
+    expect(report).toBeTruthy();
+    if (report) expect(report.brain_dir).toBe(repo);
+
+    const sources = await engine.listAllSources();
+    expect(typeof sources.find(s => s.id === 'kb')?.config.last_full_cycle_at).toBe('string');
+  });
+
+  test('--source cannot be combined with --dir', async () => {
+    const spy = spyOn(process, 'exit').mockImplementation(() => { throw new Error('EXIT'); });
+    const errSpy = spyOn(console, 'error').mockImplementation(() => {});
+    await expect(runDream(engine, ['--source', 'kb', '--dir', repo, '--json'])).rejects.toThrow('EXIT');
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('--dir cannot be combined with --source'));
+    expect(spy).toHaveBeenCalledWith(2);
+    spy.mockRestore();
+    errSpy.mockRestore();
+  });
+
   test('no --dir + engine=null exits 1', async () => {
     const spy = spyOn(process, 'exit').mockImplementation(() => { throw new Error('EXIT'); });
     const errSpy = spyOn(console, 'error').mockImplementation(() => {});

--- a/test/local-updater-contract.test.ts
+++ b/test/local-updater-contract.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readlinkSync, rmSync, symlinkSync } from 'node:fs';
+import { EventEmitter } from 'node:events';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -79,6 +80,84 @@ describe('public local updater and Codex plugin packaging', () => {
     expect(rehearsal).toMatch(/function ensureTempBrain[\s\S]*rehearsalInitArgs\(\)/);
   });
 
+  test('Codex launcher reaps gbrain serve when stdio transport closes', async () => {
+    const launcherModulePath = '../plugins/gbrain-codex/scripts/launch-gbrain-serve.mjs';
+    const { bindChildLifecycle } = await import(launcherModulePath) as {
+      bindChildLifecycle: (
+        child: EventEmitter & { exitCode: number | null; signalCode: string | null; killed: boolean; kill: (signal: string) => boolean },
+        opts: { parentProcess: EventEmitter; stdin: EventEmitter; forceKillAfterMs: number },
+      ) => () => void;
+    };
+    const parentProcess = new EventEmitter();
+    const stdin = new EventEmitter();
+    const child = new EventEmitter() as EventEmitter & {
+      exitCode: number | null;
+      signalCode: string | null;
+      killed: boolean;
+      kills: string[];
+      kill: (signal: string) => boolean;
+    };
+    child.exitCode = null;
+    child.signalCode = null;
+    child.killed = false;
+    child.kills = [];
+    child.kill = (signal: string) => {
+      child.kills.push(signal);
+      child.killed = true;
+      return true;
+    };
+
+    const cleanup = bindChildLifecycle(child, {
+      parentProcess,
+      stdin,
+      forceKillAfterMs: 5,
+    });
+    stdin.emit('close');
+    cleanup();
+
+    expect(child.kills).toEqual(['SIGTERM']);
+    expect(parentProcess.listenerCount('SIGTERM')).toBe(0);
+  });
+
+  test('Codex launcher escalates to SIGKILL when gbrain serve ignores SIGTERM', async () => {
+    const launcherModulePath = '../plugins/gbrain-codex/scripts/launch-gbrain-serve.mjs';
+    const { bindChildLifecycle } = await import(launcherModulePath) as {
+      bindChildLifecycle: (
+        child: EventEmitter & { exitCode: number | null; signalCode: string | null; killed: boolean; kill: (signal: string) => boolean },
+        opts: { parentProcess: EventEmitter; stdin: EventEmitter; forceKillAfterMs: number },
+      ) => () => void;
+    };
+    const parentProcess = new EventEmitter();
+    const stdin = new EventEmitter();
+    const child = new EventEmitter() as EventEmitter & {
+      exitCode: number | null;
+      signalCode: string | null;
+      killed: boolean;
+      kills: string[];
+      kill: (signal: string) => boolean;
+    };
+    child.exitCode = null;
+    child.signalCode = null;
+    child.killed = false;
+    child.kills = [];
+    child.kill = (signal: string) => {
+      child.kills.push(signal);
+      child.killed = true;
+      return true;
+    };
+
+    const cleanup = bindChildLifecycle(child, {
+      parentProcess,
+      stdin,
+      forceKillAfterMs: 5,
+    });
+    stdin.emit('close');
+    await new Promise(resolve => setTimeout(resolve, 15));
+    cleanup();
+
+    expect(child.kills).toEqual(['SIGTERM', 'SIGKILL']);
+  });
+
   test('Codex installer creates a local plugin shell linked to current repo skills', () => {
     const home = tempHome();
     const result = Bun.spawnSync({
@@ -115,7 +194,7 @@ describe('public local updater and Codex plugin packaging', () => {
     });
     expect(rehearsal.exitCode).toBe(0);
     expect(JSON.parse(rehearsal.stdout.toString()).ok).toBe(true);
-  });
+  }, 15000);
 
   test('Codex installer replaces stale or broken local gbrain-codex symlinks', () => {
     const home = tempHome();

--- a/test/sources.test.ts
+++ b/test/sources.test.ts
@@ -158,6 +158,48 @@ describe('sources add', () => {
   });
 });
 
+describe('sources cycle-freshness', () => {
+  test('sets cycle_freshness=false for retrieval-only sources', async () => {
+    const { engine, calls } = makeStub({
+      'SELECT id, name, local_path, last_commit, last_sync_at, config, created_at': [{
+        id: 'support-kb',
+        name: 'support-kb',
+        local_path: '/tmp/support-kb',
+        last_commit: null,
+        last_sync_at: null,
+        config: '{"federated":true}',
+        created_at: new Date(),
+      }],
+    });
+    await runSources(engine, ['cycle-freshness', 'support-kb', 'off']);
+    const update = calls.find(c => c.sql.includes('UPDATE sources SET config'));
+    expect(update).toBeDefined();
+    expect(JSON.parse(String(update!.params[0]))).toEqual({
+      federated: true,
+      cycle_freshness: false,
+    });
+    expect(update!.params[1]).toBe('support-kb');
+  });
+
+  test('removes cycle_freshness override when re-enabled', async () => {
+    const { engine, calls } = makeStub({
+      'SELECT id, name, local_path, last_commit, last_sync_at, config, created_at': [{
+        id: 'support-kb',
+        name: 'support-kb',
+        local_path: '/tmp/support-kb',
+        last_commit: null,
+        last_sync_at: null,
+        config: '{"cycle_freshness":false,"federated":true}',
+        created_at: new Date(),
+      }],
+    });
+    await runSources(engine, ['cycle-freshness', 'support-kb', 'on']);
+    const update = calls.find(c => c.sql.includes('UPDATE sources SET config'));
+    expect(update).toBeDefined();
+    expect(JSON.parse(String(update!.params[0]))).toEqual({ federated: true });
+  });
+});
+
 // ── list ────────────────────────────────────────────────────
 
 describe('sources list', () => {


### PR DESCRIPTION
Fixes the last practical doctor-score drift for Eva Brain installs: Support KB now stays searchable without being treated as a failed dream/autopilot source, Codex Desktop plugin rehearsals no longer leave stale `gbrain serve` children behind, and the skill resolver covers the `skillpack-harvest` routing phrases that were costing local doctor health. Local smoke on the installed machine now reports `gbrain doctor --json` as `healthy` with `health_score: 100` and no non-ok checks.

Closes #119.

## Why this matters

The fleet installer treats doctor health as the quick answer to “is this install ready for an agent?” The previous state could be misleading:

```mermaid
flowchart TD
  A[Support KB installed for retrieval/search] --> B[Doctor expected every federated source to run full dream cycle]
  B --> C[cycle_freshness warning]
  D[Codex plugin rehearsal starts gbrain serve] --> E[stdio closes]
  E --> F[child process could remain]
  F --> G[PGLite/doctor connection warning]
  H[Resolver routing phrase miss] --> I[resolver_health warning]
  C --> J[Doctor below 100]
  G --> J
  I --> J
```

This PR fixes those as separate root causes instead of papering over the score.

## What changed

- Marks Support KB as a retrieval-only source during public local updates:
  - `gbrain sources cycle-freshness openclaw-support-kb off`
- Adds a public CLI toggle:
  - `gbrain sources cycle-freshness <id> <on|off>`
- Makes doctor and dream autopilot respect `source.config.cycle_freshness === false`.
- Adds `gbrain dream --source <id>` so doctor’s existing remediation command actually resolves a registered source path and updates that source’s freshness row.
- Prevents dangerous ambiguity: `dream --source` cannot be combined with `--dir`.
- Adds lifecycle cleanup to the Codex Desktop `gbrain serve` launcher so closing stdio terminates the child process and escalates to SIGKILL only if needed.
- Expands `skillpack-harvest` deterministic routing phrases in `skills/RESOLVER.md`.

## Maintainer notes

The Support KB is intentionally not a full-cycle brain source. It is an installable retrieval corpus for OpenClaw/Eva support docs. Requiring dream/autopilot enrichment for that corpus makes doctor score punish a healthy, cheaper, retrieval-only setup.

The new source config bit is deliberately narrow:

```json
{
  "cycle_freshness": false
}
```

It only changes doctor/autopilot full-cycle freshness handling. It does not remove the source from search, sync, import, embeddings, or federation.

## Validation

Local focused validation from `/Volumes/LEXAR/repos/eva-brain`:

```bash
git diff --check
bun test test/doctor-cycle-freshness.test.ts test/autopilot-fanout.test.ts test/sources.test.ts test/dream.test.ts test/check-resolvable.test.ts test/local-updater-contract.test.ts
```

Result: `106 pass`, `0 fail`.

Local installed smoke:

```bash
env GBRAIN_SKILLS_DIR=/Volumes/LEXAR/repos/eva-brain/skills gbrain doctor --json
```

Result summary:

```json
{
  "status": "healthy",
  "health_score": 100,
  "non_ok": []
}
```

Additional local smoke:

- `gbrain search OpenClaw --limit 3` returned results.
- `node /Users/lume/plugins/gbrain-codex/scripts/rehearsal.mjs` returned `{ "ok": true, "toolCount": 74 }`.
- `openclaw plugins inspect gbrain --runtime --json` reports the plugin loaded with 3 tools and 1 HTTP route.
- Post-rehearsal process check found no stale `gbrain serve` or launcher process.

Full-suite validation is intentionally left to GitHub Actions per the Codex Desktop local-resource policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--source` CLI option to the `dream` command to target specific registered sources.
  * Added `sources cycle-freshness` subcommand to toggle automatic freshness checking per source.

* **Enhancements**
  * Improved child process lifecycle management and cleanup.
  * Expanded trigger phrases for skill publishing and promotion operations.
  * Extended support knowledge base update workflow.

* **Tests**
  * Added comprehensive test coverage for new source freshness and dream command features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/eva-brain/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->