### PR TITLE
Add GitHub-only stable release channel

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: latest
@@ -64,7 +64,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: latest

--- a/.github/workflows/heavy-tests.yml
+++ b/.github/workflows/heavy-tests.yml
@@ -55,7 +55,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,13 @@ name: Release
 
 on:
   push:
-    tags: ['v*']
+    tags: ['eva-v*']
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Eva release tag to publish, for example eva-v0.40.2.0'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -19,8 +25,19 @@ jobs:
             target: bun-linux-x64
             artifact: gbrain-linux-x64
     runs-on: ${{ matrix.os }}
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - name: Validate Eva release tag
+        run: |
+          set -euo pipefail
+          case "$RELEASE_TAG" in
+            eva-v*) ;;
+            *) echo "Release tags must use eva-v*, got: $RELEASE_TAG" >&2; exit 1 ;;
+          esac
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref }}
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: latest
@@ -35,14 +52,28 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           path: artifacts
+      - name: Generate checksums
+        run: |
+          set -euo pipefail
+          case "$RELEASE_TAG" in
+            eva-v*) ;;
+            *) echo "Release tags must use eva-v*, got: $RELEASE_TAG" >&2; exit 1 ;;
+          esac
+          cd artifacts
+          find . -type f -name 'gbrain-*' -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+          cat SHA256SUMS
       - name: Create release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2
         with:
+          tag_name: ${{ env.RELEASE_TAG }}
           files: |
             artifacts/gbrain-darwin-arm64/gbrain-darwin-arm64
             artifacts/gbrain-linux-x64/gbrain-linux-x64
+            artifacts/SHA256SUMS
           generate_release_notes: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
       - name: Install gitleaks
@@ -41,7 +41,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: latest

--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -25,9 +25,9 @@ cd ~/eva-brain
 scripts/update-local-install.sh
 ```
 
-That script is idempotent: it updates the checkout, runs `bun install`, links
-the `gbrain` CLI, applies safe PGLite migrations, and refreshes optional host
-plugins when those hosts are present.
+That script is idempotent: it installs the latest `eva-v*` GitHub release tag,
+runs `bun install`, links the `gbrain` CLI, applies safe PGLite migrations, and
+refreshes optional host plugins when those hosts are present.
 
 To require host plugin setup instead of auto-detecting it, pass
 `--with-openclaw` and/or `--with-codex-plugin`.
@@ -38,6 +38,12 @@ Full Eva/OpenClaw/Codex/support-KB install:
 git clone https://github.com/electricsheephq/eva-brain.git ~/eva-brain
 cd ~/eva-brain
 scripts/update-local-install.sh --with-openclaw --with-codex-plugin --with-support-kb --stop-stale-serve
+```
+
+Development installs must opt into the moving branch explicitly:
+
+```bash
+scripts/update-local-install.sh --ref master
 ```
 
 What that command does:
@@ -362,10 +368,24 @@ actually works) is the most important.
 
 ## Upgrade
 
+Stable release upgrade:
+
 ```bash
 cd ~/eva-brain
 scripts/update-local-install.sh
 gbrain post-upgrade                   # show migration notes for the version range
+```
+
+Install or roll back to an exact release:
+
+```bash
+scripts/update-local-install.sh --ref eva-v0.40.2.0
+```
+
+Development branch upgrade:
+
+```bash
+scripts/update-local-install.sh --ref master
 ```
 
 Then read `~/eva-brain/skills/migrations/v<NEW_VERSION>.md` (and any intermediate

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2061,9 +2061,9 @@ cd ~/eva-brain
 scripts/update-local-install.sh
 ```
 
-That script is idempotent: it updates the checkout, runs `bun install`, links
-the `gbrain` CLI, applies safe PGLite migrations, and refreshes optional host
-plugins when those hosts are present.
+That script is idempotent: it installs the latest `eva-v*` GitHub release tag,
+runs `bun install`, links the `gbrain` CLI, applies safe PGLite migrations, and
+refreshes optional host plugins when those hosts are present.
 
 To require host plugin setup instead of auto-detecting it, pass
 `--with-openclaw` and/or `--with-codex-plugin`.
@@ -2074,6 +2074,12 @@ Full Eva/OpenClaw/Codex/support-KB install:
 git clone https://github.com/electricsheephq/eva-brain.git ~/eva-brain
 cd ~/eva-brain
 scripts/update-local-install.sh --with-openclaw --with-codex-plugin --with-support-kb --stop-stale-serve
+```
+
+Development installs must opt into the moving branch explicitly:
+
+```bash
+scripts/update-local-install.sh --ref master
 ```
 
 What that command does:
@@ -2398,10 +2404,24 @@ actually works) is the most important.
 
 ## Upgrade
 
+Stable release upgrade:
+
 ```bash
 cd ~/eva-brain
 scripts/update-local-install.sh
 gbrain post-upgrade                   # show migration notes for the version range
+```
+
+Install or roll back to an exact release:
+
+```bash
+scripts/update-local-install.sh --ref eva-v0.40.2.0
+```
+
+Development branch upgrade:
+
+```bash
+scripts/update-local-install.sh --ref master
 ```
 
 Then read `~/eva-brain/skills/migrations/v<NEW_VERSION>.md` (and any intermediate

--- a/plugins/gbrain-codex/README.md
+++ b/plugins/gbrain-codex/README.md
@@ -55,6 +55,10 @@ cd ~/eva-brain
 scripts/update-local-install.sh --with-codex-plugin
 ```
 
+By default the updater installs the newest `eva-v*` GitHub release tag. For
+development against moving `master`, pass `--ref master`. To pin or roll back,
+pass an exact release tag such as `--ref eva-v0.40.2.0`.
+
 Add `--with-openclaw --with-support-kb` when this Codex install should share the
 same machine with OpenClaw and the OpenClaw support knowledge base.
 

--- a/plugins/openclaw-gbrain/README.md
+++ b/plugins/openclaw-gbrain/README.md
@@ -22,6 +22,10 @@ cd ~/eva-brain
 scripts/update-local-install.sh --with-openclaw
 ```
 
+By default the updater installs the newest `eva-v*` GitHub release tag. For
+development against moving `master`, pass `--ref master`. To pin or roll back,
+pass an exact release tag such as `--ref eva-v0.40.2.0`.
+
 Or install the plugin manually from an existing checkout:
 
 ```bash

--- a/scripts/update-local-install.sh
+++ b/scripts/update-local-install.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 REPO_URL="${EVA_BRAIN_REPO_URL:-https://github.com/electricsheephq/eva-brain.git}"
 INSTALL_DIR="${EVA_BRAIN_DIR:-$HOME/eva-brain}"
-REF="${EVA_BRAIN_REF:-master}"
+REF="${EVA_BRAIN_REF:-stable}"
 GBRAIN_ROOT="${GBRAIN_HOME:-$HOME}"
 if [ "${GBRAIN_ROOT%/.gbrain}" != "$GBRAIN_ROOT" ]; then
   GBRAIN_ROOT="$(dirname "$GBRAIN_ROOT")"
@@ -30,7 +30,7 @@ and optionally refreshes host plugins.
 Options:
   --dir <path>                 Checkout/install directory (default: ~/eva-brain)
   --repo <url>                 Git repo URL (default: electricsheephq/eva-brain)
-  --ref <branch-or-tag>        Git ref to checkout/pull (default: master)
+  --ref <branch-or-tag>        Git ref to checkout/pull (default: stable, latest eva-v* tag)
   --with-openclaw              Install/enable the OpenClaw native plugin
   --without-openclaw           Skip OpenClaw plugin install
   --with-codex-plugin          Install/update the Codex Desktop local plugin entry
@@ -46,12 +46,13 @@ Options:
 Environment:
   VOYAGE_API_KEY               Used by gbrain provider probes and embeddings
   EVA_BRAIN_DIR                Same as --dir
-  EVA_BRAIN_REF                Same as --ref
+  EVA_BRAIN_REF                Same as --ref. Use master only for development.
   GBRAIN_HOME                  Parent for .gbrain runtime data. If it points
                                directly at a .gbrain dir, the updater normalizes it.
 
 Examples:
   scripts/update-local-install.sh
+  scripts/update-local-install.sh --ref master
   scripts/update-local-install.sh --with-openclaw --with-codex-plugin
   scripts/update-local-install.sh --with-support-kb --stop-stale-serve
 USAGE
@@ -77,6 +78,27 @@ run() {
 
 need_cmd() {
   command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+}
+
+latest_stable_tag() {
+  git ls-remote --tags --refs --sort='version:refname' "$REPO_URL" 'eva-v*' |
+    awk '{print $2}' |
+    sed 's#refs/tags/##' |
+    tail -n 1
+}
+
+resolve_ref() {
+  if [ "$REF" != "stable" ]; then
+    return
+  fi
+  need_cmd git
+  local tag
+  tag="$(latest_stable_tag)"
+  if [ -z "$tag" ]; then
+    die "No Eva Brain release tags found in $REPO_URL. Create an eva-v* GitHub release, pass --ref <eva-v...>, or pass --ref master for a development install."
+  fi
+  log "Resolved stable to $tag"
+  REF="$tag"
 }
 
 parse_args() {
@@ -238,6 +260,7 @@ install_support_kb() {
 
 main() {
   parse_args "$@"
+  resolve_ref
   checkout_repo
   if [ -d "$INSTALL_DIR" ]; then
     cd "$INSTALL_DIR"

--- a/test/local-updater-contract.test.ts
+++ b/test/local-updater-contract.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readlinkSync, rmSync, symlinkSync } from 'node:fs';
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readlinkSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { EventEmitter } from 'node:events';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -26,11 +26,45 @@ function tempHome(): string {
   return dir;
 }
 
+function runGit(cwd: string, args: string[]): void {
+  const result = Bun.spawnSync({
+    cmd: ['git', ...args],
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(`git ${args.join(' ')} failed\n${result.stdout}\n${result.stderr}`);
+  }
+}
+
+function makeRepoWithEvaTags(home: string, tags: string[]): string {
+  const repo = join(home, 'remote-src');
+  mkdirSync(repo, { recursive: true });
+  runGit(repo, ['init']);
+  runGit(repo, ['config', 'user.email', 'agent@example.invalid']);
+  runGit(repo, ['config', 'user.name', 'Agent']);
+  writeFileSync(join(repo, 'README.md'), '# tagged repo\n');
+  runGit(repo, ['add', 'README.md']);
+  runGit(repo, ['commit', '-m', 'initial']);
+  for (const tag of tags) {
+    writeFileSync(join(repo, 'README.md'), `# tagged repo\n${tag}\n`);
+    runGit(repo, ['add', 'README.md']);
+    runGit(repo, ['commit', '-m', `release ${tag}`]);
+    runGit(repo, ['tag', tag]);
+  }
+  return repo;
+}
+
 describe('public local updater and Codex plugin packaging', () => {
   test('update script is public-host phrased and syntax-valid', () => {
     const script = readFileSync(join(root, 'scripts/update-local-install.sh'), 'utf8');
 
     expect(script).toMatch(/Usage:\s+scripts\/update-local-install\.sh\s+\[options\]/);
+    expect(script).toMatch(/REF="\$\{EVA_BRAIN_REF:-stable\}"/);
+    expect(script).toMatch(/latest_stable_tag\(\)/);
+    expect(script).toMatch(/git\s+ls-remote\s+--tags\s+--refs\s+--sort='version:refname'\s+"\$REPO_URL"\s+'eva-v\*'/);
+    expect(script).toMatch(/No Eva Brain release tags found/);
     expect(script).toMatch(/--with-openclaw\b/);
     expect(script).toMatch(/--with-codex-plugin\b/);
     expect(script).toMatch(/node\s+scripts\/install-codex-plugin\.mjs/);
@@ -49,6 +83,33 @@ describe('public local updater and Codex plugin packaging', () => {
       cwd: root,
     });
     expect(result.exitCode).toBe(0);
+  });
+
+  test('release workflow publishes only eva-v tags with binaries and checksums', () => {
+    const workflow = readFileSync(join(root, '.github/workflows/release.yml'), 'utf8');
+
+    expect(workflow).toMatch(/tags:\s+\['eva-v\*'\]/);
+    expect(workflow).toMatch(/workflow_dispatch:/);
+    expect(workflow).toContain('tag_name:');
+    expect(workflow).toContain('gbrain-darwin-arm64');
+    expect(workflow).toContain('gbrain-linux-x64');
+    expect(workflow).toContain('SHA256SUMS');
+    expect(workflow).toMatch(/tag_name:\s+\$\{\{\s*env\.RELEASE_TAG\s*\}\}/);
+    expect(workflow).toContain('Release tags must use eva-v*');
+  });
+
+  test('workflows use Node 24-ready checkout pin', () => {
+    const files = [
+      '.github/workflows/test.yml',
+      '.github/workflows/e2e.yml',
+      '.github/workflows/heavy-tests.yml',
+      '.github/workflows/release.yml',
+    ];
+    for (const file of files) {
+      const workflow = readFileSync(join(root, file), 'utf8');
+      expect(workflow).toContain('actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd');
+      expect(workflow).not.toContain('actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5');
+    }
   });
 
   test('Codex plugin metadata stays repo-owned and version-aligned', () => {
@@ -227,7 +288,69 @@ describe('public local updater and Codex plugin packaging', () => {
     expect(existsSync(join(home, '.agents/plugins/marketplace.json'))).toBe(false);
   });
 
-  test('local updater dry-run works for a missing first-install directory', () => {
+  test('local updater stable dry-run resolves the newest eva-v release tag', () => {
+    const home = tempHome();
+    const repo = makeRepoWithEvaTags(home, ['eva-v0.40.1.0', 'eva-v0.40.2.0']);
+    const installDir = join(home, 'eva-brain');
+    const result = Bun.spawnSync({
+      cmd: [
+        'bash',
+        'scripts/update-local-install.sh',
+        '--dry-run',
+        '--repo',
+        repo,
+        '--dir',
+        installDir,
+        '--without-openclaw',
+        '--without-codex-plugin',
+        '--skip-provider-test',
+        '--skip-doctor',
+      ],
+      cwd: root,
+      env: { ...process.env, HOME: home, GBRAIN_HOME: home },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    expect(result.exitCode).toBe(0);
+    const stdout = new TextDecoder().decode(result.stdout);
+    const stderr = new TextDecoder().decode(result.stderr);
+    expect(stderr).toContain('Resolved stable to eva-v0.40.2.0');
+    expect(stdout).toContain(`git clone --branch eva-v0.40.2.0 ${repo} ${installDir}`);
+    expect(stdout).not.toContain('--branch master');
+    expect(existsSync(installDir)).toBe(false);
+  });
+
+  test('local updater fails closed when stable has no eva-v release tags', () => {
+    const home = tempHome();
+    const repo = makeRepoWithEvaTags(home, []);
+    const result = Bun.spawnSync({
+      cmd: [
+        'bash',
+        'scripts/update-local-install.sh',
+        '--dry-run',
+        '--repo',
+        repo,
+        '--dir',
+        join(home, 'eva-brain'),
+        '--without-openclaw',
+        '--without-codex-plugin',
+        '--skip-provider-test',
+        '--skip-doctor',
+      ],
+      cwd: root,
+      env: { ...process.env, HOME: home, GBRAIN_HOME: home },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    expect(result.exitCode).toBe(1);
+    const stderr = new TextDecoder().decode(result.stderr);
+    expect(stderr).toContain('No Eva Brain release tags found');
+    expect(stderr).toContain('pass --ref master for a development install');
+  });
+
+  test('local updater dry-run still allows explicit master development installs', () => {
     const home = tempHome();
     const installDir = join(home, 'eva-brain');
     const result = Bun.spawnSync({
@@ -235,6 +358,8 @@ describe('public local updater and Codex plugin packaging', () => {
         'bash',
         'scripts/update-local-install.sh',
         '--dry-run',
+        '--ref',
+        'master',
         '--dir',
         installDir,
         '--without-openclaw',


### PR DESCRIPTION
## TL;DR

Refs #121. This PR creates the first GitHub-only stable release channel for Eva Brain: fleet installs now target the newest `eva-v*` GitHub release tag by default instead of moving `master`, while development installs can still opt into `--ref master` explicitly.

## Why

Customer VM updates need a stable, rollbackable install target. `master` is useful for catch-up work, but it is not a release channel: one new upstream catch-up commit can change install behavior before Golden or fleet canaries have proven it. A release tag gives us a clear answer to "what build is installed?", "what do we roll back to?", and "what did GitHub build?"

```mermaid
flowchart LR
  A[master: development + upstream catch-up] --> B[eva-v* tag]
  B --> C[GitHub Release]
  C --> D[release binaries + SHA256SUMS]
  B --> E[update-local-install stable resolver]
  E --> F[Golden canary]
  F --> G[customer VM rollout]
  G --> H[rollback by exact eva-v* tag]
```

## What Changed

- Release workflow now triggers only for `eva-v*` tags and manual dispatch with an explicit `tag_name`.
- Release artifacts include:
  - `gbrain-darwin-arm64`
  - `gbrain-linux-x64`
  - `SHA256SUMS`
- `scripts/update-local-install.sh` now defaults to `stable`, resolving the newest remote `eva-v*` tag.
- `--ref master` remains the explicit development escape hatch.
- Stable resolution fails closed if no `eva-v*` tag exists, instead of silently following moving `master`.
- Install docs and plugin READMEs now show stable installs, exact-tag rollback, and explicit dev installs.
- Touched workflows now use the Node 24-ready `actions/checkout` v6.0.2 SHA.

## Validation

Local focused checks only, per local-resource policy:

- `bash -n scripts/update-local-install.sh`
- `bun test test/local-updater-contract.test.ts` -> 15 pass
- `git diff --check`
- `actionlint .github/workflows/release.yml .github/workflows/test.yml .github/workflows/e2e.yml .github/workflows/heavy-tests.yml`

Full Test/E2E/CodeQL/gitleaks/Socket/CodeRabbit should run in GitHub on this PR.

## Post-Merge Release Steps

After this merges:

1. Create `eva-v0.40.2.0` from the merge commit.
2. Let the Release workflow publish binaries and `SHA256SUMS`.
3. Verify `gh release list` shows the release.
4. Run updater smoke with `--ref eva-v0.40.2.0`.
5. Close #121 after release assets and smoke are verified.
