### PR TITLE
Keep Eva release publish lightweight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   build:
+    timeout-minutes: 20
     strategy:
       matrix:
         include:
@@ -42,7 +43,7 @@ jobs:
         with:
           bun-version: latest
       - run: bun install
-      - run: bun test
+      - run: bun run build:openclaw
       - run: bun build --compile --target=${{ matrix.target }} --outfile bin/${{ matrix.artifact }} src/cli.ts
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
@@ -52,6 +53,7 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
     steps:

--- a/test/local-updater-contract.test.ts
+++ b/test/local-updater-contract.test.ts
@@ -94,6 +94,9 @@ describe('public local updater and Codex plugin packaging', () => {
     expect(workflow).toContain('gbrain-darwin-arm64');
     expect(workflow).toContain('gbrain-linux-x64');
     expect(workflow).toContain('SHA256SUMS');
+    expect(workflow).toContain('timeout-minutes: 20');
+    expect(workflow).toContain('bun run build:openclaw');
+    expect(workflow).not.toContain('- run: bun test');
     expect(workflow).toMatch(/tag_name:\s+\$\{\{\s*env\.RELEASE_TAG\s*\}\}/);
     expect(workflow).toContain('Release tags must use eva-v*');
   });


### PR DESCRIPTION
Refs #121

## TL;DR
The first `eva-v0.40.2.0` tag proved the release workflow was doing too much: it reran raw, unsharded `bun test` on both release platforms even though PR #122 had already passed the sharded Test, E2E, CodeQL, Socket, and gitleaks gates. This PR makes tag publishing fleet-safe: release jobs install, build OpenClaw context output, compile platform binaries, upload artifacts, and stop quickly if something wedges.

```mermaid
flowchart LR
  A[PR gates] --> B[Test shards + E2E + CodeQL green]
  B --> C[Merge to master]
  C --> D[eva-v* tag]
  D --> E[Release workflow]
  E --> F[Build OpenClaw context]
  F --> G[Compile darwin/linux gbrain binaries]
  G --> H[Publish assets + SHA256SUMS]
```

## Why
The release tag workflow should be a packaging step, not a second full CI system. Running raw `bun test` there is slower than the sharded CI path, produces worse diagnostics, and can block stable releases for hours. The stable channel already requires the full PR gates before tagging, so the release workflow should validate the release-specific contract: can this tagged commit build the expected artifacts?

## What changed
- Replaced release-job `bun test` with `bun run build:openclaw` before binary compilation.
- Added `timeout-minutes: 20` to platform build jobs.
- Added `timeout-minutes: 10` to the release asset publication job.
- Updated the local updater contract test so this behavior stays locked.

## Validation
Local focused only, per local-resource policy:

- `bash -n scripts/update-local-install.sh`
- `bun test test/local-updater-contract.test.ts`
- `actionlint .github/workflows/release.yml`
- `git diff --check`

GitHub should run the full PR gate again here. After merge, I will recreate `eva-v0.40.2.0` at the new master commit and verify release assets plus checksums.
