### PR TITLE
Emit flat SHA256SUMS for Eva release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,12 @@ jobs:
             *) echo "Release tags must use eva-v*, got: $RELEASE_TAG" >&2; exit 1 ;;
           esac
           cd artifacts
-          find . -type f -name 'gbrain-*' -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+          find . -type f -name 'gbrain-*' -print0 \
+            | sort -z \
+            | while IFS= read -r -d '' file; do
+                hash="$(sha256sum "$file" | awk '{print $1}')"
+                printf '%s  %s\n' "$hash" "$(basename "$file")"
+              done > SHA256SUMS
           cat SHA256SUMS
       - name: Create release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2

--- a/test/local-updater-contract.test.ts
+++ b/test/local-updater-contract.test.ts
@@ -96,7 +96,9 @@ describe('public local updater and Codex plugin packaging', () => {
     expect(workflow).toContain('SHA256SUMS');
     expect(workflow).toContain('timeout-minutes: 20');
     expect(workflow).toContain('bun run build:openclaw');
+    expect(workflow).toContain('basename "$file"');
     expect(workflow).not.toContain('- run: bun test');
+    expect(workflow).not.toContain('xargs -0 sha256sum > SHA256SUMS');
     expect(workflow).toMatch(/tag_name:\s+\$\{\{\s*env\.RELEASE_TAG\s*\}\}/);
     expect(workflow).toContain('Release tags must use eva-v*');
   });


### PR DESCRIPTION
Refs #121

## TL;DR
The first GitHub release assets built correctly, but `SHA256SUMS` used the internal artifact directory paths (`./gbrain-linux-x64/gbrain-linux-x64`) instead of the flat asset filenames users get from `gh release download`. This PR makes the checksum file verify directly against downloaded release assets.

```mermaid
flowchart LR
  A[download release assets] --> B[gbrain-darwin-arm64]
  A --> C[gbrain-linux-x64]
  A --> D[SHA256SUMS]
  D --> E[shasum -a 256 -c SHA256SUMS]
  B --> E
  C --> E
```

## Why
For fleet installs and agent-run rollback checks, the checksum command should be boring: download the release assets, run `shasum -a 256 -c SHA256SUMS`, and get `OK`. Internal artifact folder names are an implementation detail of GitHub Actions and should not leak into the public checksum contract.

## What changed
- Generate checksums with `basename "$file"` so `SHA256SUMS` contains flat asset names.
- Add a contract assertion so the release workflow does not regress to raw artifact paths.

## Validation
Local focused only:

- `bun test test/local-updater-contract.test.ts`
- `actionlint .github/workflows/release.yml`
- `git diff --check`

After merge, I will recreate `eva-v0.40.2.0`, rerun release publishing, download the assets, and verify `shasum -a 256 -c SHA256SUMS` passes directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release automation to improve checksum generation consistency during artifact publishing.
  * Enhanced release workflow validation tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/eva-brain/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->