### PR TITLE
Archive dirty Support KB checkouts during updater runs

### DIFF
--- a/scripts/update-local-install.sh
+++ b/scripts/update-local-install.sh
@@ -246,7 +246,15 @@ install_support_kb() {
   local kb_repo="${OPENCLAW_SUPPORT_KB_REPO:-https://github.com/electricsheephq/openclaw-support-kb.git}"
   local kb_dir="${OPENCLAW_SUPPORT_KB_DIR:-$GBRAIN_DIR/sources/openclaw-support-kb}"
   if [ -d "$kb_dir/.git" ]; then
-    run git -C "$kb_dir" pull --ff-only
+    if [ -n "$(git -C "$kb_dir" status --porcelain)" ]; then
+      local backup_dir="$GBRAIN_DIR/backups/openclaw-support-kb-$(date -u +%Y%m%dT%H%M%SZ)"
+      log "Support KB checkout has local changes; archiving it to $backup_dir before reinstalling"
+      run mkdir -p "$(dirname "$backup_dir")"
+      run mv "$kb_dir" "$backup_dir"
+      run git clone "$kb_repo" "$kb_dir"
+    else
+      run git -C "$kb_dir" pull --ff-only
+    fi
   else
     run mkdir -p "$(dirname "$kb_dir")"
     run git clone "$kb_repo" "$kb_dir"

--- a/test/local-updater-contract.test.ts
+++ b/test/local-updater-contract.test.ts
@@ -388,6 +388,59 @@ describe('public local updater and Codex plugin packaging', () => {
     expect(existsSync(installDir)).toBe(false);
   });
 
+  test('local updater archives dirty Support KB checkouts before reinstalling', () => {
+    const home = tempHome();
+    const repo = makeRepoWithEvaTags(home, []);
+    const kbRepo = makeRepoWithEvaTags(tempHome(), []);
+    const kbDir = join(home, '.gbrain/sources/openclaw-support-kb');
+    mkdirSync(kbDir, { recursive: true });
+    runGit(kbDir, ['init']);
+    runGit(kbDir, ['config', 'user.email', 'agent@example.invalid']);
+    runGit(kbDir, ['config', 'user.name', 'Agent']);
+    writeFileSync(join(kbDir, 'kb-manifest.json'), '{}\n');
+    runGit(kbDir, ['add', 'kb-manifest.json']);
+    runGit(kbDir, ['commit', '-m', 'initial kb']);
+    writeFileSync(join(kbDir, 'kb-manifest.json'), '{"dirty":true}\n');
+    writeFileSync(join(kbDir, 'local-only.md'), '# local only\n');
+
+    const result = Bun.spawnSync({
+      cmd: [
+        'bash',
+        'scripts/update-local-install.sh',
+        '--dry-run',
+        '--ref',
+        'master',
+        '--repo',
+        repo,
+        '--dir',
+        join(home, 'eva-brain'),
+        '--with-support-kb',
+        '--without-openclaw',
+        '--without-codex-plugin',
+        '--skip-provider-test',
+        '--skip-doctor',
+      ],
+      cwd: root,
+      env: {
+        ...process.env,
+        HOME: home,
+        GBRAIN_HOME: home,
+        OPENCLAW_SUPPORT_KB_DIR: kbDir,
+        OPENCLAW_SUPPORT_KB_REPO: kbRepo,
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    expect(result.exitCode).toBe(0);
+    const stdout = new TextDecoder().decode(result.stdout);
+    const stderr = new TextDecoder().decode(result.stderr);
+    expect(stderr).toContain('Support KB checkout has local changes; archiving it');
+    expect(stdout).toContain(`mv ${kbDir}`);
+    expect(stdout).toContain(`git clone ${kbRepo} ${kbDir}`);
+    expect(stdout).not.toContain(`git -C ${kbDir} pull --ff-only`);
+  });
+
   test('Codex installer rejects missing option values instead of falling back to cwd', () => {
     for (const flag of ['--home', '--repo-dir']) {
       const result = Bun.spawnSync({


### PR DESCRIPTION
Refs #121

## TL;DR
The exact-tag local updater successfully installed Eva Brain, refreshed the OpenClaw plugin, and installed the Codex plugin, then failed on Support KB because the existing managed KB checkout had local edits and untracked skill files. This PR makes the public updater fleet-safe for that case: dirty managed Support KB checkouts are archived before a clean reinstall instead of breaking the upgrade halfway through.

```mermaid
flowchart TD
  A[Updater --with-support-kb] --> B{KB checkout exists?}
  B -- no --> C[clone Support KB]
  B -- yes --> D{git status clean?}
  D -- yes --> E[git pull --ff-only]
  D -- no --> F[move checkout to .gbrain/backups]
  F --> C
  C --> G[run KB client update/status]
  E --> G
  G --> H[gbrain sync/embed source]
```

## Why
Fleet machines can accumulate local KB edits from previous agent runs, generated resolver files, or one-off debugging. A managed updater should not die on `git pull --ff-only` and leave the install half-upgraded. It also should not silently delete local changes. Archiving the dirty checkout gives us a clean managed install path while preserving the old files for inspection.

## What changed
- If `~/.gbrain/sources/openclaw-support-kb` is dirty, move it to `~/.gbrain/backups/openclaw-support-kb-<timestamp>`.
- Clone a fresh Support KB checkout after archiving.
- Keep clean checkouts on the fast path: `git pull --ff-only`.
- Add a dry-run contract test proving dirty KB uses archive+clone, not pull.

## Validation
Local focused only:

- `bash -n scripts/update-local-install.sh`
- `bun test test/local-updater-contract.test.ts`
- `git diff --check`

After merge I will retag `eva-v0.40.2.0`, verify release assets/checksums again, and rerun the local exact-tag updater smoke.
