### PR TITLE
Fix facts backstop test gateway isolation

### DIFF
--- a/test/facts-anti-loop.test.ts
+++ b/test/facts-anti-loop.test.ts
@@ -6,10 +6,11 @@
  *   - put_page backstop on dream_generated:true frontmatter → skipped:dream_generated
  */
 
-import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { describe, test, expect, beforeAll, beforeEach, afterAll } from 'bun:test';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { dispatchToolCall } from '../src/mcp/dispatch.ts';
 import { extractFactsFromTurn } from '../src/core/facts/extract.ts';
+import { configureGateway, resetGateway } from '../src/core/ai/gateway.ts';
 
 let engine: PGLiteEngine;
 
@@ -24,10 +25,25 @@ beforeAll(async () => {
 }, 30_000);
 
 afterAll(async () => {
-  await engine.disconnect();
+  try {
+    await engine.disconnect();
+  } finally {
+    resetGateway();
+  }
 }, 30_000);
 
 describe('anti-loop dream_generated marker', () => {
+  beforeEach(() => {
+    // This file validates facts backstop gating, not embedding. The global
+    // legacy preload can inherit CI's fake OPENAI_API_KEY=sk-test and make
+    // put_page attempt a real embedding call before the backstop runs.
+    configureGateway({
+      embedding_model: 'openai:text-embedding-3-large',
+      embedding_dimensions: 1536,
+      env: {},
+    });
+  });
+
   test('extractFactsFromTurn skips when isDreamGenerated:true', async () => {
     const r = await extractFactsFromTurn({
       turnText: 'This would normally produce facts about Sam.',

--- a/test/facts-backstop-gating.test.ts
+++ b/test/facts-backstop-gating.test.ts
@@ -8,9 +8,10 @@
  * responses.
  */
 
-import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { describe, test, expect, beforeAll, beforeEach, afterAll } from 'bun:test';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { dispatchToolCall } from '../src/mcp/dispatch.ts';
+import { configureGateway, resetGateway } from '../src/core/ai/gateway.ts';
 
 let engine: PGLiteEngine;
 
@@ -21,7 +22,11 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  await engine.disconnect();
+  try {
+    await engine.disconnect();
+  } finally {
+    resetGateway();
+  }
 });
 
 async function putAndReadBackstop(slug: string, content: string): Promise<{ queued: boolean } | { skipped: string } | undefined> {
@@ -35,6 +40,17 @@ async function putAndReadBackstop(slug: string, content: string): Promise<{ queu
 }
 
 describe('put_page facts backstop', () => {
+  beforeEach(() => {
+    // These tests assert put_page facts-backstop eligibility only. Keep the
+    // gateway configured but credentialless so CI's fake OPENAI_API_KEY does
+    // not route importFromContent into a real embedding attempt first.
+    configureGateway({
+      embedding_model: 'openai:text-embedding-3-large',
+      embedding_dimensions: 1536,
+      env: {},
+    });
+  });
+
   test('skipped on too-short body', async () => {
     const result = await putAndReadBackstop(
       'note/short',


### PR DESCRIPTION
## TL;DR
Fixes post-merge `master` CI by isolating facts backstop tests from the global legacy embedding preload. The tests now explicitly configure a credentialless gateway, so CI fake keys cannot make `put_page` call the real OpenAI embedding endpoint before facts assertions run.

Closes #131.

## Why
`bunfig.toml` preloads `test/helpers/legacy-embedding-preload.ts`, which configures OpenAI/1536 so older vector fixtures keep working. In CI, the shard had `OPENAI_API_KEY=sk-test`, so the preload made `isAvailable(embedding)` true. These facts tests are not embedding tests; they only need `put_page` to write and return `facts_backstop`.

## What Changed
- `test/facts-anti-loop.test.ts` now configures an OpenAI/1536 gateway with `env: {}` before each test.
- `test/facts-backstop-gating.test.ts` gets the same isolation, because it exercises the same `put_page` facts-backstop surface.
- Both files reset the gateway on teardown.

## Local Focused Validation
Ran from `/Volumes/LEXAR/repos/eva-brain-post-merge-fix`:

```bash
OPENAI_API_KEY=sk-test bun test test/facts-anti-loop.test.ts
OPENAI_API_KEY=sk-test bun test test/facts-backstop-gating.test.ts
OPENAI_API_KEY=sk-test bun test test/facts-anti-loop.test.ts test/facts-backstop-gating.test.ts
git diff --check
```

All focused checks passed. Full suite remains GitHub-owned per the local resource policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by resetting gateway state between runs to avoid cross-test interference.
  * Added controlled test setup for embedding parameters (model and dimensions) to ensure consistent behavior.
  * Ensured gateway configuration is cleaned up after suites complete to maintain a stable test lifecycle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/eva-brain/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->