### PR TITLE
Fix provider-free heavy frontmatter init

### DIFF
--- a/tests/heavy/frontmatter_scan_wallclock.sh
+++ b/tests/heavy/frontmatter_scan_wallclock.sh
@@ -78,9 +78,10 @@ done
 SEED_ELAPSED=$((SECONDS - SEED_START))
 echo "[fm_wallclock] fixture seeded in ${SEED_ELAPSED}s" | tee -a "$LOG"
 
-# Step 2: init brain + register the source.
+# Step 2: init brain + register the source. This heavy test never embeds
+# content, so keep CI provider-free instead of requiring real API credentials.
 echo "[fm_wallclock] init brain..." | tee -a "$LOG"
-timeout 120s bun run src/cli.ts init --pglite --yes >> "$LOG" 2>&1 || {
+timeout 120s bun run src/cli.ts init --pglite --yes --no-embedding >> "$LOG" 2>&1 || {
   echo "[fm_wallclock] FAIL: gbrain init exited non-zero" >&2
   echo "Log tail:" >&2
   tail -30 "$LOG" >&2

--- a/tests/heavy/frontmatter_scan_wallclock.sh
+++ b/tests/heavy/frontmatter_scan_wallclock.sh
@@ -91,7 +91,7 @@ timeout 120s bun run src/cli.ts init --pglite --yes --no-embedding >> "$LOG" 2>&
 # Register the brain dir as a source. Use raw SQL since `gbrain sources add`
 # might not exist in this version-window; the schema is what doctor reads.
 echo "[fm_wallclock] register source..." | tee -a "$LOG"
-bun run -e "
+bun -e "
 import { PGLiteEngine } from './src/core/pglite-engine.ts';
 const e = new PGLiteEngine();
 await e.connect({});

--- a/tests/heavy/sync_lock_regression.sh
+++ b/tests/heavy/sync_lock_regression.sh
@@ -83,6 +83,8 @@ bun run src/cli.ts config set sync.repo_path "$BRAIN_DIR" >/dev/null 2>&1 || tru
 
 # Step 3: spawn N parallel sync processes. Capture each one's exit code +
 # stdout/stderr. The race for the lock happens during their startup window.
+# Embeddings are unrelated to the writer-lock contract, so keep this scheduled
+# heavy test provider-free.
 PIDS=()
 EXIT_FILES=()
 OUT_FILES=()
@@ -91,7 +93,7 @@ for ((i=1; i<=NUM_PARALLEL; i+=1)); do
   OUT_F=$(mktemp -t sync-lock-out-XXXXXX)
   EXIT_FILES+=("$EXIT_F")
   OUT_FILES+=("$OUT_F")
-  ( bun run src/cli.ts sync --dir "$BRAIN_DIR" >"$OUT_F" 2>&1; echo $? > "$EXIT_F" ) &
+  ( bun run src/cli.ts sync --dir "$BRAIN_DIR" --no-embed >"$OUT_F" 2>&1; echo $? > "$EXIT_F" ) &
   PIDS+=($!)
 done
 

--- a/tests/heavy/sync_lock_regression.sh
+++ b/tests/heavy/sync_lock_regression.sh
@@ -78,8 +78,13 @@ EOF
 # git-init so sync's diff-walk has something to anchor (sync expects a git repo)
 (cd "$BRAIN_DIR" && git init -q && git add . && git -c user.email=test@test -c user.name=test commit -q -m "seed" >/dev/null 2>&1) || true
 
-# Tell gbrain to use this brain dir
-bun run src/cli.ts config set sync.repo_path "$BRAIN_DIR" >/dev/null 2>&1 || true
+# Tell current source-aware sync to use this brain dir. Older versions read
+# sync.repo_path, but current sync resolves the default source local_path.
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -v brain_path="$BRAIN_DIR" -c \
+  "INSERT INTO sources (id, name, local_path, config)
+   VALUES ('default', 'default', :'brain_path', '{}'::jsonb)
+   ON CONFLICT (id) DO UPDATE SET local_path = EXCLUDED.local_path;" \
+  >/dev/null 2>>"$LOG"
 
 # Step 3: spawn N parallel sync processes. Capture each one's exit code +
 # stdout/stderr. The race for the lock happens during their startup window.

--- a/tests/heavy/sync_lock_regression.sh
+++ b/tests/heavy/sync_lock_regression.sh
@@ -80,9 +80,10 @@ EOF
 
 # Tell current source-aware sync to use this brain dir. Older versions read
 # sync.repo_path, but current sync resolves the default source local_path.
-psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -v brain_path="$BRAIN_DIR" -c \
+escaped_brain_dir=${BRAIN_DIR//\'/\'\'}
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c \
   "INSERT INTO sources (id, name, local_path, config)
-   VALUES ('default', 'default', :'brain_path', '{}'::jsonb)
+   VALUES ('default', 'default', '$escaped_brain_dir', '{}'::jsonb)
    ON CONFLICT (id) DO UPDATE SET local_path = EXCLUDED.local_path;" \
   >/dev/null 2>>"$LOG"
 


### PR DESCRIPTION
## TL;DR
Fixes the scheduled Heavy Tests failure on current master. The affected heavy scripts validate frontmatter scan timing and sync lock behavior; neither test needs live embeddings, so they should run provider-free instead of requiring real provider credentials.

Closes #143.

## What changed
- `tests/heavy/frontmatter_scan_wallclock.sh` now runs `gbrain init --pglite --yes --no-embedding`.
- The same script uses `bun -e` instead of `bun run -e`, which current Bun treats as invalid usage.
- `tests/heavy/sync_lock_regression.sh` now registers the default source `local_path` directly, matching current source-aware sync behavior.
- The sync lock test runs concurrent sync processes with `--no-embed`, keeping the writer-lock contract isolated from provider credentials.

## Validation
- Local focused only from `/Volumes/LEXAR/repos/eva-brain-heavy-test-fix`:
  - `bash -n tests/heavy/frontmatter_scan_wallclock.sh`
  - `bash -n tests/heavy/sync_lock_regression.sh`
  - `git diff --check`
- GitHub opt-in `Heavy Tests` is triggered by the `heavy-tests` label.

## Why this is safe
These tests do not validate embedding quality or provider behavior. They validate doctor/frontmatter walker timing and sync writer-lock exclusion. Making them provider-free and source-aware removes unrelated CI dependencies without weakening the tested contracts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Disabled embedding generation during heavy-load test initialization and in concurrent lock-regression runs.
  * Updated how the smoke test runs inline execution for improved compatibility.
  * Switched the lock-regression setup to configure the sync target via a database update.
  * Clarified test comments about embed-free providers and writer-lock behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/eva-brain/pull/144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->