### PR TITLE
Fix updater restoring missing gbrain shim

### DIFF
--- a/scripts/update-local-install.sh
+++ b/scripts/update-local-install.sh
@@ -192,11 +192,35 @@ ensure_bun() {
   die "Bun is required. Install it from https://bun.sh, then rerun this script."
 }
 
+ensure_gbrain_cli() {
+  if [ "$DRY_RUN" = "true" ]; then
+    return
+  fi
+
+  local global_bin="$HOME/.bun/bin/gbrain"
+  local checkout_bin="$INSTALL_DIR/src/cli.ts"
+
+  if [ -x "$global_bin" ]; then
+    return
+  fi
+
+  if [ -x "$checkout_bin" ]; then
+    log "Restoring missing gbrain CLI shim: $global_bin -> $checkout_bin"
+    run mkdir -p "$(dirname "$global_bin")"
+    run ln -sfn "$checkout_bin" "$global_bin"
+  fi
+
+  if [ ! -x "$global_bin" ]; then
+    die "gbrain CLI was not linked at $global_bin. Run from a valid Eva Brain checkout or reinstall with Bun, then rerun this updater."
+  fi
+}
+
 install_gbrain() {
   ensure_bun
   export PATH="$HOME/.bun/bin:$PATH"
   run bun install
   run bun link
+  ensure_gbrain_cli
   stop_stale_serve_if_requested
   local config_path="$GBRAIN_DIR/config.json"
   if [ -f "$config_path" ]; then

--- a/test/local-updater-contract.test.ts
+++ b/test/local-updater-contract.test.ts
@@ -506,6 +506,70 @@ describe('public local updater and Codex plugin packaging', () => {
     expect(existsSync(installDir)).toBe(false);
   });
 
+  test('local updater restores missing Bun-global gbrain shim from checked-out CLI', () => {
+    const home = tempHome();
+    const repo = makeRepoWithEvaTags(home, []);
+    mkdirSync(join(repo, 'src'), { recursive: true });
+    writeFileSync(
+      join(repo, 'src/cli.ts'),
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "init" ]; then
+  exit 0
+fi
+if [ "\${1:-}" = "version" ]; then
+  echo "gbrain test"
+  exit 0
+fi
+echo "unexpected gbrain args: $*" >&2
+exit 3
+`,
+    );
+    chmodSync(join(repo, 'src/cli.ts'), 0o755);
+    runGit(repo, ['add', 'src/cli.ts']);
+    runGit(repo, ['commit', '-m', 'add fake cli']);
+
+    const binDir = join(home, '.bun/bin');
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(join(binDir, 'bun'), '#!/usr/bin/env bash\nexit 0\n');
+    chmodSync(join(binDir, 'bun'), 0o755);
+
+    const installDir = join(home, 'eva-brain');
+    const result = Bun.spawnSync({
+      cmd: [
+        'bash',
+        'scripts/update-local-install.sh',
+        '--ref',
+        'master',
+        '--repo',
+        repo,
+        '--dir',
+        installDir,
+        '--without-openclaw',
+        '--without-codex-plugin',
+        '--without-workspace-docs',
+        '--skip-provider-test',
+        '--skip-doctor',
+        '--skip-health',
+      ],
+      cwd: root,
+      env: {
+        ...process.env,
+        HOME: home,
+        PATH: `${binDir}:${process.env.PATH ?? ''}`,
+        GBRAIN_HOME: home,
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    const stderr = new TextDecoder().decode(result.stderr);
+    expect(result.exitCode).toBe(0);
+    expect(stderr).toContain('Restoring missing gbrain CLI shim');
+    expect(lstatSync(join(binDir, 'gbrain')).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(binDir, 'gbrain'))).toBe(join(installDir, 'src/cli.ts'));
+  });
+
   test('local updater archives dirty Support KB checkouts before reinstalling', () => {
     const home = tempHome();
     const repo = makeRepoWithEvaTags(home, []);


### PR DESCRIPTION
## TLDR

Fixes #155. OpenClaw agents can lose GBrain even when the brain is healthy if `$HOME/.bun/bin/gbrain` disappears. This PR makes the updater restore that public shim from the checked-out `src/cli.ts` before it runs `gbrain init`, so existing OpenClaw configs and compatibility shims keep working.

## Why

A local Eva/OpenClaw agent hit:

```text
spawn /Users/lume/.bun/bin/gbrain ENOENT
```

The database was not broken: the checked-out Eva Brain CLI still worked, Support KB search returned results, and OpenClaw plugin metadata loaded. The problem was purely launcher/install drift:

```mermaid
flowchart LR
  A["OpenClaw GBrain tool"] --> B["configured gbrainBin"]
  B --> C["$HOME/.bun/bin/gbrain"]
  C --> D{"exists?"}
  D -- "no" --> E["spawn ENOENT"]
  D -- "yes" --> F["healthy local GBrain CLI"]
```

Because local configs, runbooks, and legacy compatibility shims already call `$HOME/.bun/bin/gbrain`, the safest fix is to preserve that contract instead of forcing every host to rewrite config.

## What Changed

- Adds `ensure_gbrain_cli` to `scripts/update-local-install.sh`.
- After `bun install` + `bun link`, the updater checks `$HOME/.bun/bin/gbrain`.
- If the Bun-global shim is missing but the checked-out `src/cli.ts` is executable, it restores:

```bash
$HOME/.bun/bin/gbrain -> $INSTALL_DIR/src/cli.ts
```

- If neither executable path exists, the updater fails clearly before attempting `gbrain init`.
- Adds a regression test that simulates Bun existing without a `gbrain` global shim and verifies the updater restores it before init.

## Validation

Local focused checks only, from `/Volumes/LEXAR/repos/eva-brain-fix-gbrain-bin`:

```bash
bash -n scripts/update-local-install.sh
bun install --frozen-lockfile --ignore-scripts
bun test test/local-updater-contract.test.ts
```

Result: `22 pass, 0 fail`.

Also repaired the affected local host by restoring `/Users/lume/.bun/bin/gbrain` as a shim to `/Volumes/LEXAR/repos/eva-brain/src/cli.ts`; `openclaw gbrain status` now works and reports populated `openclaw-support-kb` and `workspace-docs` sources.

## Notes

This does not rebuild any brain database. It only repairs the launcher path contract.
