### PR TITLE
Allow release branch to create Eva tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     tags: ['eva-v*']
+    branches: ['release/eva-v*']
   workflow_dispatch:
     inputs:
       tag_name:
@@ -14,7 +15,36 @@ permissions:
   contents: write
 
 jobs:
+  create-tag:
+    if: startsWith(github.ref, 'refs/heads/release/eva-v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Create matching Eva release tag
+        run: |
+          set -euo pipefail
+          release_tag="${GITHUB_REF_NAME#release/}"
+          case "$release_tag" in
+            eva-v*) ;;
+            *) echo "Release branches must use release/eva-v*, got: $GITHUB_REF_NAME" >&2; exit 1 ;;
+          esac
+          expected="eva-v$(node -p "require('./package.json').version")"
+          if [ "$release_tag" != "$expected" ]; then
+            echo "Release tag must match package.json version: expected $expected, got $release_tag" >&2
+            exit 1
+          fi
+          if git ls-remote --exit-code origin "refs/tags/$release_tag" >/dev/null 2>&1; then
+            echo "Tag $release_tag already exists"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$release_tag" "$GITHUB_SHA" -m "Eva Brain ${release_tag#eva-v}"
+          git push origin "refs/tags/$release_tag"
+
   build:
+    if: startsWith(github.ref, 'refs/tags/eva-v') || github.event_name == 'workflow_dispatch'
     timeout-minutes: 20
     strategy:
       matrix:
@@ -59,6 +89,7 @@ jobs:
           path: bin/${{ matrix.artifact }}
 
   release:
+    if: startsWith(github.ref, 'refs/tags/eva-v') || github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
## TLDR

Closes #172. This keeps the normal `eva-v*` tag release path, but adds a repo-owned fallback: pushing/creating `release/eva-vX.Y.Z` can create the matching real `eva-vX.Y.Z` tag from GitHub Actions when local tag push is unavailable.

## Why

The fleet updater installs exact `eva-v*` tags, which is the right safety model. The problem is operational: this Codex host can merge via the GitHub connector, but cannot push tags locally because `gh` has no token and SSH is blocked by a local UID lookup failure. Release publication should not depend on one operator shell.

```mermaid
flowchart TD
  A[Master has package version X] --> B[Create release/eva-vX branch]
  B --> C[GitHub Actions validates package version]
  C --> D[Actions creates real eva-vX tag]
  D --> E[Existing tag workflow builds binaries]
  E --> F[gbrain-darwin-arm64 + gbrain-linux-x64 + SHA256SUMS]
```

## What changed

- Adds `release/eva-v*` branch trigger to the Release workflow.
- Adds a `create-tag` job that runs only for release branches.
- Validates the branch-derived tag matches `package.json` before creating anything.
- Keeps build/release jobs gated to actual `eva-v*` tags or manual dispatch, so branch-triggered runs do not duplicate release assets.

## Validation

- Workflow-only change; GitHub Actions will validate YAML and repository checks on this PR.
- The release branch fallback will be proven by creating `release/eva-v0.42.47.6` after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow automation and tag management processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->