### PR TITLE
Fix Eva release branch asset publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,8 @@ jobs:
           git push origin "refs/tags/$release_tag"
 
   build:
-    if: startsWith(github.ref, 'refs/tags/eva-v') || github.event_name == 'workflow_dispatch'
+    needs: create-tag
+    if: always() && (needs.create-tag.result == 'success' || needs.create-tag.result == 'skipped') && (startsWith(github.ref, 'refs/tags/eva-v') || startsWith(github.ref, 'refs/heads/release/eva-v') || github.event_name == 'workflow_dispatch')
     timeout-minutes: 20
     strategy:
       matrix:
@@ -56,16 +57,22 @@ jobs:
             target: bun-linux-x64
             artifact: gbrain-linux-x64
     runs-on: ${{ matrix.os }}
-    env:
-      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
     steps:
-      - name: Validate Eva release tag
+      - name: Resolve Eva release tag
         run: |
           set -euo pipefail
-          case "$RELEASE_TAG" in
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            release_tag="${{ inputs.tag_name }}"
+          elif [[ "$GITHUB_REF" == refs/heads/release/eva-v* ]]; then
+            release_tag="${GITHUB_REF_NAME#release/}"
+          else
+            release_tag="$GITHUB_REF_NAME"
+          fi
+          case "$release_tag" in
             eva-v*) ;;
-            *) echo "Release tags must use eva-v*, got: $RELEASE_TAG" >&2; exit 1 ;;
+            *) echo "Release tags must use eva-v*, got: $release_tag" >&2; exit 1 ;;
           esac
+          echo "RELEASE_TAG=$release_tag" >> "$GITHUB_ENV"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref }}
@@ -89,13 +96,26 @@ jobs:
           path: bin/${{ matrix.artifact }}
 
   release:
-    if: startsWith(github.ref, 'refs/tags/eva-v') || github.event_name == 'workflow_dispatch'
+    if: startsWith(github.ref, 'refs/tags/eva-v') || startsWith(github.ref, 'refs/heads/release/eva-v') || github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    env:
-      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
     steps:
+      - name: Resolve Eva release tag
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            release_tag="${{ inputs.tag_name }}"
+          elif [[ "$GITHUB_REF" == refs/heads/release/eva-v* ]]; then
+            release_tag="${GITHUB_REF_NAME#release/}"
+          else
+            release_tag="$GITHUB_REF_NAME"
+          fi
+          case "$release_tag" in
+            eva-v*) ;;
+            *) echo "Release tags must use eva-v*, got: $release_tag" >&2; exit 1 ;;
+          esac
+          echo "RELEASE_TAG=$release_tag" >> "$GITHUB_ENV"
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           path: artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,10 +59,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Resolve Eva release tag
+        env:
+          INPUT_TAG_NAME: ${{ inputs.tag_name }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            release_tag="${{ inputs.tag_name }}"
+            release_tag="$INPUT_TAG_NAME"
           elif [[ "$GITHUB_REF" == refs/heads/release/eva-v* ]]; then
             release_tag="${GITHUB_REF_NAME#release/}"
           else
@@ -102,10 +104,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Resolve Eva release tag
+        env:
+          INPUT_TAG_NAME: ${{ inputs.tag_name }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            release_tag="${{ inputs.tag_name }}"
+            release_tag="$INPUT_TAG_NAME"
           elif [[ "$GITHUB_REF" == refs/heads/release/eva-v* ]]; then
             release_tag="${GITHUB_REF_NAME#release/}"
           else


### PR DESCRIPTION
Closes #178.

## TL;DR

Release branches should produce complete Eva release artifacts, not just create a source tag. This PR fixes the release workflow so `release/eva-v*` branch pushes create or reuse the matching tag, then build and upload `gbrain-darwin-arm64`, `gbrain-linux-x64`, and `SHA256SUMS` in the same workflow run.

## Why

The `.8` rollout candidate exposed a release-channel gap: `release/eva-v0.42.47.8` created the tag, but GitHub did not run the tag-triggered build afterward because tag pushes made by `GITHUB_TOKEN` do not recursively trigger workflows. The result was a visible source-only release, which is not good enough for a fleet rollout gate.

```mermaid
flowchart LR
  A[release/eva-v* branch] --> B[validate package version]
  B --> C[create matching tag if missing]
  C --> D[build macOS + Linux binaries]
  D --> E[upload binaries + SHA256SUMS]
```

## What Changed

- Allows the `build` and `release` jobs to run on `release/eva-v*` branch events.
- Keeps tag events and manual `workflow_dispatch` working.
- Resolves `RELEASE_TAG` safely for branch, tag, and manual-dispatch events.
- Keeps the existing version/tag validation intact.

## Validation

- Local focused check: `git diff --check` passed.
- GitHub CI/release workflow will validate the actual branch behavior after merge by re-running `release/eva-v0.42.47.8`.

## Fleet Impact

No runtime code changes. This is release plumbing only; fleet rollout remains pinned to `eva-v0.42.47.8` after the release assets are published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD release workflow configuration to improve job orchestration and release tag resolution logic.

---

**Note:** This release contains only internal infrastructure updates with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->