### PR TITLE
Fix Eva release asset publication after tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,8 +98,8 @@ jobs:
           path: bin/${{ matrix.artifact }}
 
   release:
-    if: startsWith(github.ref, 'refs/tags/eva-v') || startsWith(github.ref, 'refs/heads/release/eva-v') || github.event_name == 'workflow_dispatch'
     needs: build
+    if: always() && needs.build.result == 'success' && (startsWith(github.ref, 'refs/tags/eva-v') || startsWith(github.ref, 'refs/heads/release/eva-v') || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/test/local-updater-contract.test.ts
+++ b/test/local-updater-contract.test.ts
@@ -214,7 +214,9 @@ describe('public local updater and Codex plugin packaging', () => {
     expect(workflow).toContain('Validate release tag matches package version');
     expect(workflow).toContain("require('./package.json').version");
     expect(workflow).toContain('Release tag must match package.json version');
-    expect(workflow).toContain("always() && needs.build.result == 'success'");
+    const releaseJob = workflow.match(/\n  release:\n[\s\S]*?(?=\n  [a-zA-Z0-9_-]+:\n|$)/)?.[0] ?? '';
+    expect(releaseJob).toContain("needs: build");
+    expect(releaseJob).toContain("if: always() && needs.build.result == 'success'");
   });
 
   test('test workflow uses OSS gitleaks CLI without an organization license secret', () => {

--- a/test/local-updater-contract.test.ts
+++ b/test/local-updater-contract.test.ts
@@ -214,6 +214,7 @@ describe('public local updater and Codex plugin packaging', () => {
     expect(workflow).toContain('Validate release tag matches package version');
     expect(workflow).toContain("require('./package.json').version");
     expect(workflow).toContain('Release tag must match package.json version');
+    expect(workflow).toContain("always() && needs.build.result == 'success'");
   });
 
   test('test workflow uses OSS gitleaks CLI without an organization license secret', () => {


### PR DESCRIPTION
## TL;DR

Fixes the Eva release workflow so an `eva-v*` tag push publishes the GitHub Release assets instead of stopping after the binary build artifacts.

Closes #183.

## Why

`eva-v0.42.56.0` exposed a workflow graph bug: both binary build jobs passed, but the `release` job was skipped, leaving no GitHub Release, no `gbrain-darwin-arm64`, no `gbrain-linux-x64`, and no `SHA256SUMS` for the updater to consume.

The intended `create-tag` job is skipped on direct tag pushes. `build` already handles that with `always()` and an explicit result check. `release` needed the same style of guard so GitHub does not skip it because a sibling/upstream graph leg was skipped.

## What Changed

- `release` now uses `always() && needs.build.result == 'success' && (...)`.
- Added a contract assertion so future edits keep this behavior visible.

## Validation

- `git diff --check` ✅
- `bun install --frozen-lockfile` ✅
- `bun test test/local-updater-contract.test.ts` ✅ 26 pass

## Follow-Up After Merge

- Re-run the Release workflow with `workflow_dispatch` for `eva-v0.42.56.0`.
- Verify the GitHub Release has:
  - `gbrain-darwin-arm64`
  - `gbrain-linux-x64`
  - `SHA256SUMS`
- Continue exact-tag local canary only after those assets exist.
