### PR TITLE
Fix admin release asset and OSV coverage gates

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -12,6 +12,8 @@ on:
     paths:
       - 'bun.lock'
       - 'package.json'
+      - 'admin/bun.lock'
+      - 'admin/package.json'
   schedule:
     - cron: '30 6 * * 1'  # weekly, Monday 06:30 UTC
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ export/
 
 # Local OpenClaw bundle output. Release jobs rebuild this from source.
 dist/
+!admin/dist/
+!admin/dist/**
 
 # Tier 3 PGLite snapshot fixture (built on demand by build:pglite-snapshot)
 test/fixtures/pglite-snapshot.tar

--- a/test/release-distribution-contract.test.ts
+++ b/test/release-distribution-contract.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+describe('release distribution contract', () => {
+  test('generic dist output stays ignored while admin SPA assets remain trackable', () => {
+    const ignored = Bun.spawnSync(
+      ['git', 'check-ignore', '--no-index', '--quiet', 'dist/openclaw-plugin.js'],
+      { cwd: repoRoot },
+    );
+    const adminAsset = Bun.spawnSync(
+      ['git', 'check-ignore', '--no-index', '--quiet', 'admin/dist/assets/index-future-hash.js'],
+      { cwd: repoRoot },
+    );
+
+    expect(ignored.exitCode).toBe(0);
+    expect(adminAsset.exitCode).toBe(1);
+  });
+
+  test('OSV pull-request filter includes root and admin dependency manifests', () => {
+    const workflow = readFileSync(join(repoRoot, '.github/workflows/osv-scanner.yml'), 'utf8');
+
+    expect(workflow).toContain("- 'bun.lock'");
+    expect(workflow).toContain("- 'package.json'");
+    expect(workflow).toContain("- 'admin/bun.lock'");
+    expect(workflow).toContain("- 'admin/package.json'");
+  });
+});


### PR DESCRIPTION
## TL;DR

This closes the two release-gate gaps split from #201: future content-hashed `admin/dist` assets remain trackable, and admin dependency-only pull requests now trigger OSV scanning. It is intentionally tiny and blocks the `eva-v0.42.63.1` tag.

Closes #202.

## Why

The compiled GBrain binary embeds the committed admin SPA. A bare `dist/` ignore pattern also matched `admin/dist/`, so a future Vite build could update `index.html` to reference a newly hashed JavaScript asset that Git silently ignored. Existing tracked files hid the problem.

The admin package also has its own lockfile and security overrides. OSV previously ran only when root manifests changed, leaving admin-only dependency changes outside the pull-request scan.

## Changes

- keep generic `dist/` output ignored;
- explicitly unignore `admin/dist/` and its contents;
- add `admin/package.json` and `admin/bun.lock` to the OSV pull-request filter;
- add a behavioral contract test using `git check-ignore`, plus a workflow-path assertion.

## Proof

- `git diff --check`
- `bun test test/release-distribution-contract.test.ts`: **2/2 pass**
- full GitHub CI and one independent semantic release/security review remain required before merge.

## Proof boundary

This proves source and workflow readiness for the release. The release tag/assets and local exact-tag canary remain separate post-merge gates.
