### PR TITLE
fix(deps): override vulnerable Hono Node adapter

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,7 +51,7 @@
     "@electric-sql/pglite",
   ],
   "overrides": {
-    "@hono/node-server": "^1.19.13",
+    "@hono/node-server": "2.0.10",
     "body-parser": "^2.3.0",
     "fast-uri": "^3.1.2",
     "fast-xml-builder": "^1.1.7",
@@ -163,7 +163,7 @@
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.4.3", "", {}, "sha512-ichuWTgtd4mOM1G4SpyGJa5trT03lWbMypDV0fUXUCXg5hiHqVAz/bZyV68NqmkLB7WcYmj1RMJVSp8HV/v/ZQ=="],
 
-    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+    "@hono/node-server": ["@hono/node-server@2.0.10", "", { "peerDependencies": { "hono": "^4" } }, "sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA=="],
 
     "@jsquash/avif": ["@jsquash/avif@2.1.1", "", { "dependencies": { "wasm-feature-detect": "^1.2.11" } }, "sha512-LMRxd0fMgfCLtobDh0/sFYJMMiRJTNYSEEWvRDKXlAeZ08t3gI5V+1thIT0XjXJ+SVG7Zug9B0XPyx0Ti5VRNA=="],
 

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
   "license": "MIT",
   "version": "0.42.63.1",
   "overrides": {
-    "@hono/node-server": "^1.19.13",
+    "@hono/node-server": "2.0.10",
     "body-parser": "^2.3.0",
     "fast-uri": "^3.1.2",
     "fast-xml-builder": "^1.1.7",


### PR DESCRIPTION
## TL;DR

Required OSV checks began failing on GHSA-frvp-7c67-39w9 in `@hono/node-server@1.19.14`. Eva/GBrain does not import that adapter and serves HTTP through `Bun.serve`, but the vulnerable transitive package remained in the lockfile. This PR moves the existing override to fixed `2.0.10`, clearing the distributed dependency and release gate without changing server code.

Closes #206.

## Exposure

The advisory affects Windows static-file serving through Hono Node/Bun/Deno adapters when middleware guards a prefix and a request contains encoded backslashes. No Eva/GBrain source imports `@hono/node-server`, and current HTTP transport uses `Bun.serve`. There is no observed exploit path in Eva; removing the vulnerable resolved package is still preferable to suppressing the scanner.

## Change

```mermaid
flowchart LR
  A[MCP SDK requests Hono adapter 1.x] --> B[Root override]
  B --> C[Fixed adapter 2.0.10]
  C --> D[One non-vulnerable lockfile resolution]
```

- Change the root override from vulnerable 1.x to exact `2.0.10`.
- Refresh `bun.lock`.
- Do not change HTTP/MCP implementation.

## Validation

- Lockfile resolves only `@hono/node-server@2.0.10`.
- 108 focused MCP/HTTP/security tests passed.
- `git diff --check` passed.
- Full Test/E2E and OSV run in GitHub.

## Upstream

After this downstream gate is green, the same minimal override should be proposed to Garry if current upstream still resolves vulnerable 1.x.

Advisory: https://osv.dev/vulnerability/GHSA-frvp-7c67-39w9